### PR TITLE
Changed StyledTextAreaBehavior to not catch mnemonic combinations

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextAreaBehavior.java
@@ -153,9 +153,9 @@ class StyledTextAreaBehavior {
 
         Predicate<KeyEvent> noControlKeys = e ->
                 // filter out control keys
-                (!e.isControlDown() && !e.isMetaDown())
+                (!e.isControlDown() && !e.isMetaDown() && !e.isAltDown())
                 // except on Windows allow the Ctrl+Alt combination (produced by AltGr)
-                || (isWindows && !e.isMetaDown() && (!e.isControlDown() || e.isAltDown()));
+                || (isWindows && !e.isMetaDown() && e.isControlDown() == e.isAltDown());
 
         Predicate<KeyEvent> isChar = e ->
                 e.getCode().isLetterKey() ||

--- a/richtextfx/src/test/java/org/fxmisc/richtext/StyledTextAreaBehaviorTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/StyledTextAreaBehaviorTest.java
@@ -1,0 +1,52 @@
+package org.fxmisc.richtext;
+
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static javafx.scene.input.KeyEvent.KEY_PRESSED;
+
+@RunWith(Parameterized.class)
+public class StyledTextAreaBehaviorTest {
+
+    private static StyledTextArea area;
+    private final KeyEvent event;
+    private final boolean shouldBeConsumed;
+
+    public StyledTextAreaBehaviorTest(KeyEvent event, boolean shouldBeConsumed) {
+        this.event = event;
+        this.shouldBeConsumed = shouldBeConsumed;
+    }
+
+    @Parameterized.Parameters
+    public static Object[][] data() {
+        area = new CodeArea();
+        return new Object[][]{
+            //with Unmodified; Level 1
+            {new KeyEvent(area, area, KEY_PRESSED, "f", "f", KeyCode.F, false, false, false, false), true},
+            //with Shift; Level 2
+            {new KeyEvent(area, area, KEY_PRESSED, "f", "F", KeyCode.F, true, false, false, false), true},
+            //with AltGr; Level 3
+            {new KeyEvent(area, area, KEY_PRESSED, "f", "ð", KeyCode.F, false, false, false, false), true},
+            //with Shift + AltGr; Level 4
+            {new KeyEvent(area, area, KEY_PRESSED, "f", "ª", KeyCode.F, false, false, false, false), true},
+            //with Ctrl
+            {new KeyEvent(area, area, KEY_PRESSED, "f", "", KeyCode.F, false, true, false, false), false},
+            //with Alt
+            {new KeyEvent(area, area, KEY_PRESSED, "f", "", KeyCode.F, false, false, true, false), false},
+            //with Meta
+            {new KeyEvent(area, area, KEY_PRESSED, "f", "", KeyCode.F, false, false, false, true), false},
+            };
+    }
+
+    @Test
+    public void testKeyboardLevels() {
+        area.fireEvent(event);
+
+        Assert.assertEquals(shouldBeConsumed, event.isConsumed());
+    }
+}
+


### PR DESCRIPTION
Fix for https://github.com/TomasMikula/RichTextFX/issues/350

On Unix systems Alt Gr will trigger neither Alt nor Ctrl to be pressed, on Windows it triggers both. As you want to let Alt Gr be a captured by `StyledTextArea` on Windows I changed the condition for it to let Alt be passed through and Alt Gr be captured. Although I still think that Alt Gr should also not be caught on Windows as it is not used to print characters there.

PS.: this is the private account of @jakob-erdmann
