### PR TITLE
Only fire MouseOverText END event when a BEGIN event has already fired

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/view/MouseOverTextDelayTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/view/MouseOverTextDelayTests.java
@@ -58,14 +58,13 @@ public class MouseOverTextDelayTests extends InlineCssTextAreaAppTest {
         assertFalse(endFired.get());
     }
 
-    @Ignore("END events are fired multiple times when BEGIN event hasn't yet fired")
     @Test
     public void eventsFireAfterDelayAndPostMove() {
         setDelay(100);
 
         moveTo(firstLineOfArea()).sleep(300);
         assertTrue(beginFired.get());
-        assertFalse(endFired.get());    // fails here
+        assertFalse(endFired.get());
 
         resetBegin();
 
@@ -74,27 +73,21 @@ public class MouseOverTextDelayTests extends InlineCssTextAreaAppTest {
         assertTrue(endFired.get());
     }
 
-    @Ignore("setting delay while mouse is over text fires END event when BEGIN event hasn't yet fired")
     @Test
-    public void settingDelayWhileMouseOverTextDoesNotFireEvent() {
+    public void settingDelayWhileMouseAlreadyOverTextDoesNotFireEvent() {
         setDelay(null);
 
-        moveTo(firstLineOfArea()).sleep(300);
+        moveTo(firstLineOfArea());
         assertFalse(beginFired.get());
         assertFalse(endFired.get());
 
         setDelay(100);
         assertFalse(beginFired.get());
         assertFalse(endFired.get());
-
-        moveBy(20, 0);
-        assertTrue(beginFired.get());   // fails here
-        assertFalse(endFired.get());
     }
 
-    @Ignore("this test is only important when above two tests get fixed")
     @Test
-    public void settingDelayBeforeEndFiresPreventsEndFromFiring() {
+    public void settingDelayToNullValueBeforeEndFiresPreventsEndFromFiring() {
         setDelay(100);
 
         moveTo(firstLineOfArea()).sleep(200);
@@ -104,19 +97,21 @@ public class MouseOverTextDelayTests extends InlineCssTextAreaAppTest {
         resetBegin();
         setDelay(null);
 
-        moveMouseOutsideOfArea();
+        moveBy(20, 0);
         assertFalse(beginFired.get());
         assertFalse(endFired.get());
+    }
 
+    @Test
+    public void settingDelayToNonNullValueBeforeEndFiresStillFiresEndEvent() {
         setDelay(100);
-        assertFalse(beginFired.get());
-        assertFalse(endFired.get());
 
-        moveTo(firstLineOfArea()).sleep(300);
+        moveTo(firstLineOfArea()).sleep(200);
         assertTrue(beginFired.get());
         assertFalse(endFired.get());
 
         resetBegin();
+        setDelay(200);
 
         moveBy(20, 0);
         assertFalse(beginFired.get());

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -114,7 +114,7 @@ class ParagraphBox<PS, SEG, S> extends Region {
         return text.getParagraph();
     }
 
-    public EventStream<Either<Tuple2<Point2D, Integer>, Object>> stationaryIndices(Duration delay) {
+    public EventStream<Either<Tuple2<Point2D, Integer>, Object>> stationaryIndices(Duration delay, BooleanProperty beginEventFired) {
         EventStream<Either<Point2D, Void>> stationaryEvents = new MouseStationaryHelper(this).events(delay);
         EventStream<Tuple2<Point2D, Integer>> hits = stationaryEvents.filterMap(Either::asLeft)
                 .filterMap(p -> {
@@ -125,7 +125,9 @@ class ParagraphBox<PS, SEG, S> extends Region {
                         return Optional.empty();
                     }
                 });
-        EventStream<?> stops = stationaryEvents.filter(Either::isRight).map(Either::getRight);
+        EventStream<?> stops = stationaryEvents.filter(Either::isRight).map(Either::getRight)
+                // only fire END event when a BEGIN event has already been fired
+                .conditionOn(beginEventFired);
         return hits.or(stops);
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
@@ -58,7 +58,13 @@ public interface ViewActions<PS, SEG, S> {
      * Defines how long the mouse has to stay still over the text before a
      * {@link MouseOverTextEvent} of type {@code MOUSE_OVER_TEXT_BEGIN} is
      * fired on this text area. When set to {@code null}, no
-     * {@code MouseOverTextEvent}s are fired on this text area.
+     * {@code MouseOverTextEvent}s are fired on this text area. After the begin
+     * event has fired, the corresponding end event will fire immediately after a
+     * new {@link MouseEvent} is detected. If a delay is set, the begin event is fired,
+     * and the delay is set to {@code null}, no end event will fire. If a delay is set,
+     * the begin event is fired, and a new non-null delay is set, the end event will
+     * still fire under the same conditions as normal.
+     *
      *
      * <p>Default value is {@code null}.
      */


### PR DESCRIPTION
Fixes #506.

If a delay is set, a BEGIN event is fired, and the delay is set to `null`, the corresponding END event does not currently fire when another MouseEvent is fired. Is that desired? This behavior does not occur (i.e. the END event does fire when another MouseEvent is fired) when the delay is set to a non-null delay value.

**Edit:** The above "bug" might be something we want to change in the future, but for right now, it's not a high priority. Thus, I'm going to leave this as the default behavior. I've updated the javadoc to note this quirk.