### PR TITLE
Allow RichtTextFX to access Java9 hidden methods

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/hyperlink/HyperlinkDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/hyperlink/HyperlinkDemo.java
@@ -1,11 +1,14 @@
 package org.fxmisc.richtext.demo.hyperlink;
 
-import com.sun.deploy.uitoolkit.impl.fx.HostServicesFactory;
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import org.fxmisc.flowless.VirtualizedScrollPane;
 
+import java.awt.*;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.function.Consumer;
 
 /**
@@ -21,7 +24,16 @@ public class HyperlinkDemo extends Application {
 
     @Override
     public void start(Stage primaryStage) {
-        Consumer<String> showLink = HostServicesFactory.getInstance(this)::showDocument;
+        Consumer<String> showLink = (string) -> {
+            try
+            {
+                Desktop.getDesktop().browse(new URI(string));
+            }
+            catch (IOException | URISyntaxException e)
+            {
+                throw new RuntimeException(e);
+            }
+        };
         TextHyperlinkArea area = new TextHyperlinkArea(showLink);
 
         area.appendText("Some text in the area\n");

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/hyperlink/TextHyperlinkArea.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/hyperlink/TextHyperlinkArea.java
@@ -65,7 +65,7 @@ public class TextHyperlinkArea extends GenericStyledArea<Void, Either<String, Hy
 
         // XXX: binding selectionFill to textFill,
         // see the note at highlightTextFill
-        t.impl_selectionFillProperty().bind(t.fillProperty());
+        t.selectionFillProperty().bind(t.fillProperty());
         return t;
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -133,7 +133,7 @@ public class StyledTextArea<PS, S> extends GenericStyledArea<PS, String, S> {
 
         // XXX: binding selectionFill to textFill,
         // see the note at highlightTextFill
-        t.impl_selectionFillProperty().bind(t.fillProperty());
+        t.selectionFillProperty().bind(t.fillProperty());
         return t;
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextExt.java
@@ -4,14 +4,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.sun.javafx.css.converters.EnumConverter;
-import com.sun.javafx.css.converters.SizeConverter;
-
 import javafx.beans.property.ObjectProperty;
 import javafx.css.CssMetaData;
 import javafx.css.StyleConverter;
 import javafx.css.Styleable;
 import javafx.css.StyleableObjectProperty;
+import javafx.css.converter.EnumConverter;
+import javafx.css.converter.SizeConverter;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 import javafx.scene.shape.StrokeLineCap;

--- a/richtextfx/src/main/java/org/fxmisc/richtext/j9adapters/GenericIceBreaker.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/j9adapters/GenericIceBreaker.java
@@ -1,0 +1,61 @@
+package org.fxmisc.richtext.j9adapters;
+
+import java.lang.reflect.*;
+
+public class GenericIceBreaker implements InvocationHandler {
+    private final Object delegate;
+
+    public GenericIceBreaker(Object delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        Method delegateMethod = delegate.getClass().getDeclaredMethod(method.getName(), method.getParameterTypes());
+        if (!delegateMethod.canAccess(delegate)) {
+            delegateMethod.setAccessible(true);
+        }
+
+        Object delegateMethodReturn = null;
+        try {
+            delegateMethodReturn = delegateMethod.invoke(delegate, args);
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            throw new RuntimeException("problems invoking " + method.getName());
+        }
+        if (delegateMethodReturn == null) {
+            return null;
+        }
+
+        if (method.getReturnType().isArray()) {
+            if (method.getReturnType().getComponentType().isInterface()
+                    && !method.getReturnType().getComponentType().equals(delegateMethod.getReturnType().getComponentType())) {
+
+                int arrayLength = Array.getLength(delegateMethodReturn);
+                Object retArray = Array.newInstance(method.getReturnType().getComponentType(), arrayLength);
+                for (int i = 0; i < arrayLength; i++) {
+                    Array.set(retArray,
+                            i,
+                            proxy(
+                                    method.getReturnType().getComponentType(),
+                                    Array.get(delegateMethodReturn, i)));
+                }
+
+                return retArray;
+            }
+        }
+
+        if (method.getReturnType().isInterface()
+                && !method.getReturnType().equals(delegateMethod.getReturnType())) {
+            return proxy(method.getReturnType(), delegateMethodReturn);
+        }
+
+        return delegateMethodReturn;
+    }
+
+    public static <T> T proxy(Class<T> iface, Object delegate) {
+        return (T) Proxy.newProxyInstance(
+                iface.getClassLoader(),
+                new Class[]{iface},
+                new GenericIceBreaker(delegate));
+    }
+}

--- a/richtextfx/src/main/java/org/fxmisc/richtext/j9adapters/RectBounds.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/j9adapters/RectBounds.java
@@ -1,0 +1,10 @@
+package org.fxmisc.richtext.j9adapters;
+
+public interface RectBounds
+{
+    float getMinX();
+
+    float getMaxX();
+
+    float getHeight();
+}

--- a/richtextfx/src/main/java/org/fxmisc/richtext/j9adapters/TextLayout.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/j9adapters/TextLayout.java
@@ -1,0 +1,10 @@
+package org.fxmisc.richtext.j9adapters;
+
+public interface TextLayout
+{
+    TextLine[] getLines();
+
+    int getLineIndex(float y);
+
+    int getCharCount();
+}

--- a/richtextfx/src/main/java/org/fxmisc/richtext/j9adapters/TextLine.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/j9adapters/TextLine.java
@@ -1,0 +1,10 @@
+package org.fxmisc.richtext.j9adapters;
+
+public interface TextLine
+{
+    int getLength();
+
+    RectBounds getBounds();
+
+    int getStart();
+}


### PR DESCRIPTION
This pull request let you compile and use RichtTextFX with Java 9.
Methods, where possible, are changed to their public Java 9 counterparts.
Methods still private (only in TextFlowExt) are still used using reflection but in a way which does not even require the hidden classes to be visible.
Thus, you can use RichtTextFx without runtime switches.