### PR TITLE
moved ParagraphText specific code from createStyledTextNode() methods to class ParagraphText

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/hyperlink/TextHyperlinkArea.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/hyperlink/TextHyperlinkArea.java
@@ -62,10 +62,6 @@ public class TextHyperlinkArea extends GenericStyledArea<Void, Either<String, Hy
         TextExt t = new TextExt();
         t.setTextOrigin(VPos.TOP);
         applySegment.accept(t);
-
-        // XXX: binding selectionFill to textFill,
-        // see the note at highlightTextFill
-        t.impl_selectionFillProperty().bind(t.fillProperty());
         return t;
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -112,7 +112,15 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
 //        });
 
         // populate with text nodes
-        par.getStyledSegments().stream().map(nodeFactory).forEach(getChildren()::add);
+        par.getStyledSegments().stream().map(nodeFactory).forEach(n -> {
+            if (n instanceof TextExt) {
+                TextExt t = (TextExt) n;
+                // XXX: binding selectionFill to textFill,
+                // see the note at highlightTextFill
+                t.impl_selectionFillProperty().bind(t.fillProperty());
+            }
+            getChildren().add(n);
+        });
 
         // set up custom css shape helpers
         Supplier<Path> createBackgroundShape = () -> {
@@ -406,8 +414,8 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
                 T lastShapeValue = lastShapeValueRange._1;
 
                 // calculate smallest possible position which is consecutive to the given start position
-                final int prevEndNext = lastShapeValueRange.get2().getEnd() + 1;  
-                if (start <= prevEndNext &&         // Consecutive? 
+                final int prevEndNext = lastShapeValueRange.get2().getEnd() + 1;
+                if (start <= prevEndNext &&         // Consecutive?
                     lastShapeValue.equals(value)) { // Same style?
 
                     IndexRange lastRange = lastShapeValueRange._2;

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextArea.java
@@ -130,10 +130,6 @@ public class StyledTextArea<PS, S> extends GenericStyledArea<PS, String, S> {
         t.setTextOrigin(VPos.TOP);
         t.getStyleClass().add("text");
         applyStyle.accept(t, style);
-
-        // XXX: binding selectionFill to textFill,
-        // see the note at highlightTextFill
-        t.impl_selectionFillProperty().bind(t.fillProperty());
         return t;
     }
 }


### PR DESCRIPTION
The moved code is IMHO an implementation detail that belongs to class `ParagraphText` and not to demos.

As stated in [this comment](https://github.com/FXMisc/RichTextFX/pull/614#issuecomment-336666986) I'm still not sure whether binding `TextExt.selectionFill` to `TextExt.fill` makes any sense. I can't see any difference without this binding. In PR #428 I've also removed this binding and replace with binding `TextExt.selectionFill` to `ParagraphText.highlightTextFill`, but as long as the JDK is not fixed, styling text color of selection does not work at all...