### PR TITLE
Get viewport height; show paragraph region; clean up source code (boilerplate & organization)

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -360,12 +360,9 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     @Override public ObjectProperty<Duration> mouseOverTextDelayProperty() { return mouseOverTextDelay; }
 
     private final ObjectProperty<IntFunction<? extends Node>> paragraphGraphicFactory = new SimpleObjectProperty<>(null);
-    @Override
-    public void setParagraphGraphicFactory(IntFunction<? extends Node> factory) { paragraphGraphicFactory.set(factory); }
-    @Override
-    public IntFunction<? extends Node> getParagraphGraphicFactory() { return paragraphGraphicFactory.get(); }
-    @Override
-    public ObjectProperty<IntFunction<? extends Node>> paragraphGraphicFactoryProperty() { return paragraphGraphicFactory; }
+    @Override public void setParagraphGraphicFactory(IntFunction<? extends Node> factory) { paragraphGraphicFactory.set(factory); }
+    @Override public IntFunction<? extends Node> getParagraphGraphicFactory() { return paragraphGraphicFactory.get(); }
+    @Override public ObjectProperty<IntFunction<? extends Node>> paragraphGraphicFactoryProperty() { return paragraphGraphicFactory; }
 
     private ObjectProperty<ContextMenu> contextMenu = new SimpleObjectProperty<>(null);
     @Override public final ContextMenu getContextMenu() { return contextMenu.get(); }
@@ -382,36 +379,25 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     @Override public final void setContextMenuYOffset(double offset) { contextMenuYOffset = offset; }
 
     private final BooleanProperty useInitialStyleForInsertion = new SimpleBooleanProperty();
-    @Override
-    public BooleanProperty useInitialStyleForInsertionProperty() { return useInitialStyleForInsertion; }
-    @Override
-    public void setUseInitialStyleForInsertion(boolean value) { useInitialStyleForInsertion.set(value); }
-    @Override
-    public boolean getUseInitialStyleForInsertion() { return useInitialStyleForInsertion.get(); }
+    @Override public BooleanProperty useInitialStyleForInsertionProperty() { return useInitialStyleForInsertion; }
+    @Override public void setUseInitialStyleForInsertion(boolean value) { useInitialStyleForInsertion.set(value); }
+    @Override public boolean getUseInitialStyleForInsertion() { return useInitialStyleForInsertion.get(); }
 
     private Optional<Tuple2<Codec<PS>, Codec<StyledSegment<SEG, S>>>> styleCodecs = Optional.empty();
-    @Override
-    public void setStyleCodecs(Codec<PS> paragraphStyleCodec, Codec<StyledSegment<SEG, S>> styledSegCodec) {
+    @Override public void setStyleCodecs(Codec<PS> paragraphStyleCodec, Codec<StyledSegment<SEG, S>> styledSegCodec) {
         styleCodecs = Optional.of(t(paragraphStyleCodec, styledSegCodec));
     }
-    @Override
-    public Optional<Tuple2<Codec<PS>, Codec<StyledSegment<SEG, S>>>> getStyleCodecs() {
+    @Override public Optional<Tuple2<Codec<PS>, Codec<StyledSegment<SEG, S>>>> getStyleCodecs() {
         return styleCodecs;
     }
 
-    @Override
-    public Var<Double> estimatedScrollXProperty() { return virtualFlow.estimatedScrollXProperty(); }
-    @Override
-    public double getEstimatedScrollX() { return virtualFlow.estimatedScrollXProperty().getValue(); }
-    @Override
-    public void setEstimatedScrollX(double value) { virtualFlow.estimatedScrollXProperty().setValue(value); }
+    @Override public Var<Double> estimatedScrollXProperty() { return virtualFlow.estimatedScrollXProperty(); }
+    @Override public double getEstimatedScrollX() { return virtualFlow.estimatedScrollXProperty().getValue(); }
+    @Override public void setEstimatedScrollX(double value) { virtualFlow.estimatedScrollXProperty().setValue(value); }
 
-    @Override
-    public Var<Double> estimatedScrollYProperty() { return virtualFlow.estimatedScrollYProperty(); }
-    @Override
-    public double getEstimatedScrollY() { return virtualFlow.estimatedScrollYProperty().getValue(); }
-    @Override
-    public void setEstimatedScrollY(double value) { virtualFlow.estimatedScrollYProperty().setValue(value); }
+    @Override public Var<Double> estimatedScrollYProperty() { return virtualFlow.estimatedScrollYProperty(); }
+    @Override public double getEstimatedScrollY() { return virtualFlow.estimatedScrollYProperty().getValue(); }
+    @Override public void setEstimatedScrollY(double value) { virtualFlow.estimatedScrollYProperty().setValue(value); }
 
     /* ********************************************************************** *
      *                                                                        *
@@ -504,16 +490,12 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     @Override public final boolean isBeingUpdated() { return beingUpdated.get(); }
 
     // total width estimate
-    @Override
-    public Val<Double> totalWidthEstimateProperty() { return virtualFlow.totalWidthEstimateProperty(); }
-    @Override
-    public double getTotalWidthEstimate() { return virtualFlow.totalWidthEstimateProperty().getValue(); }
+    @Override public Val<Double> totalWidthEstimateProperty() { return virtualFlow.totalWidthEstimateProperty(); }
+    @Override public double getTotalWidthEstimate() { return virtualFlow.totalWidthEstimateProperty().getValue(); }
 
     // total height estimate
-    @Override
-    public Val<Double> totalHeightEstimateProperty() { return virtualFlow.totalHeightEstimateProperty(); }
-    @Override
-    public double getTotalHeightEstimate() { return virtualFlow.totalHeightEstimateProperty().getValue(); }
+    @Override public Val<Double> totalHeightEstimateProperty() { return virtualFlow.totalHeightEstimateProperty(); }
+    @Override public double getTotalHeightEstimate() { return virtualFlow.totalHeightEstimateProperty().getValue(); }
 
     /* ********************************************************************** *
      *                                                                        *
@@ -562,8 +544,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     @Override public final PS getInitialParagraphStyle() { return initialParagraphStyle; }
 
     private final BiConsumer<TextFlow, PS> applyParagraphStyle;
-    @Override
-    public final BiConsumer<TextFlow, PS> getApplyParagraphStyle() { return applyParagraphStyle; }
+    @Override public final BiConsumer<TextFlow, PS> getApplyParagraphStyle() { return applyParagraphStyle; }
 
     // TODO: Currently, only undo/redo respect this flag.
     private final boolean preserveStyle;

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1407,16 +1407,8 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                 .map(c -> c.getNode().getRangeBoundsOnScreen(from, to));
     }
 
-    private <T> void subscribeTo(EventStream<T> src, Consumer<T> cOnsumer) {
-        manageSubscription(src.subscribe(cOnsumer));
-    }
-
     private void manageSubscription(Subscription subscription) {
         subscriptions = subscriptions.and(subscription);
-    }
-
-    private void manageBinding(Binding<?> binding) {
-        subscriptions = subscriptions.and(binding::dispose);
     }
 
     private static Bounds extendLeft(Bounds b, double w) {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -293,15 +293,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      */
     public static final IndexRange EMPTY_RANGE = new IndexRange(0, 0);
 
-    /**
-     * Private helper method.
-     */
-    private static int clamp(int min, int val, int max) {
-        return val < min ? min
-                : val > max ? max
-                : val;
-    }
-
     private static final PseudoClass READ_ONLY = PseudoClass.getPseudoClass("read-only");
     private static final PseudoClass HAS_CARET = PseudoClass.getPseudoClass("has-caret");
     private static final PseudoClass FIRST_PAR = PseudoClass.getPseudoClass("first-paragraph");

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1113,6 +1113,11 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         suspendVisibleParsWhile(() -> virtualFlow.showAsLast(paragraphIndex));
     }
 
+    @Override
+    public void showParagraphRegion(int paragraphIndex, Bounds region) {
+        suspendVisibleParsWhile(() -> virtualFlow.show(paragraphIndex, region));
+    }
+
     void showCaretAtBottom() {
         int parIdx = getCurrentParagraph();
         Cell<Paragraph<PS, SEG, S>, ParagraphBox<PS, SEG, S>> cell = virtualFlow.getCell(parIdx);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -781,10 +781,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         return getCell(paragraphIndex).getCaretOffsetX();
     }
 
-    double getViewportHeight() {
-        return virtualFlow.getHeight();
-    }
-
     CharacterHit hit(ParagraphBox.CaretOffsetX x, TwoDimensional.Position targetLine) {
         int parIdx = targetLine.getMajor();
         ParagraphBox<PS, SEG, S> cell = virtualFlow.getCell(parIdx).getNode();
@@ -807,6 +803,11 @@ public class GenericStyledArea<PS, SEG, S> extends Region
             CharacterHit parHit = cell.hitText(x, cellOffset.getY());
             return parHit.offset(parOffset);
         }
+    }
+
+    @Override
+    public final double getViewportHeight() {
+        return virtualFlow.getHeight();
     }
 
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -21,9 +21,10 @@ import javafx.beans.binding.Binding;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.ObjectBinding;
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.Property;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
@@ -336,14 +337,10 @@ public class GenericStyledArea<PS, SEG, S> extends Region
             ((Region) getBean()).pseudoClassStateChanged(READ_ONLY, !get());
         }
     };
-    @Override public final boolean isEditable() { return editable.get(); }
-    @Override public final void setEditable(boolean value) { editable.set(value); }
     @Override public final BooleanProperty editableProperty() { return editable; }
 
     // wrapText property
     private final BooleanProperty wrapText = new SimpleBooleanProperty(this, "wrapText");
-    @Override public final boolean isWrapText() { return wrapText.get(); }
-    @Override public final void setWrapText(boolean value) { wrapText.set(value); }
     @Override public final BooleanProperty wrapTextProperty() { return wrapText; }
 
     // undo manager
@@ -355,33 +352,24 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     }
 
     private final ObjectProperty<Duration> mouseOverTextDelay = new SimpleObjectProperty<>(null);
-    @Override public void setMouseOverTextDelay(Duration delay) { mouseOverTextDelay.set(delay); }
-    @Override public Duration getMouseOverTextDelay() { return mouseOverTextDelay.get(); }
     @Override public ObjectProperty<Duration> mouseOverTextDelayProperty() { return mouseOverTextDelay; }
 
     private final ObjectProperty<IntFunction<? extends Node>> paragraphGraphicFactory = new SimpleObjectProperty<>(null);
-    @Override public void setParagraphGraphicFactory(IntFunction<? extends Node> factory) { paragraphGraphicFactory.set(factory); }
-    @Override public IntFunction<? extends Node> getParagraphGraphicFactory() { return paragraphGraphicFactory.get(); }
     @Override public ObjectProperty<IntFunction<? extends Node>> paragraphGraphicFactoryProperty() { return paragraphGraphicFactory; }
 
     private ObjectProperty<ContextMenu> contextMenu = new SimpleObjectProperty<>(null);
-    @Override public final ContextMenu getContextMenu() { return contextMenu.get(); }
-    @Override public final void setContextMenu(ContextMenu menu) { contextMenu.setValue(menu); }
     @Override public final ObjectProperty<ContextMenu> contextMenuObjectProperty() { return contextMenu; }
+
     protected final boolean isContextMenuPresent() { return contextMenu.get() != null; }
 
-    private double contextMenuXOffset = 2;
-    @Override public final double getContextMenuXOffset() { return contextMenuXOffset; }
-    @Override public final void setContextMenuXOffset(double offset) { contextMenuXOffset = offset; }
+    private DoubleProperty contextMenuXOffset = new SimpleDoubleProperty(2);
+    @Override public final DoubleProperty contextMenuXOffsetProperty() { return contextMenuXOffset; }
 
-    private double contextMenuYOffset = 2;
-    @Override public final double getContextMenuYOffset() { return contextMenuYOffset; }
-    @Override public final void setContextMenuYOffset(double offset) { contextMenuYOffset = offset; }
+    private DoubleProperty contextMenuYOffset = new SimpleDoubleProperty(2);
+    @Override public final DoubleProperty contextMenuYOffsetProperty() { return contextMenuYOffset; }
 
     private final BooleanProperty useInitialStyleForInsertion = new SimpleBooleanProperty();
     @Override public BooleanProperty useInitialStyleForInsertionProperty() { return useInitialStyleForInsertion; }
-    @Override public void setUseInitialStyleForInsertion(boolean value) { useInitialStyleForInsertion.set(value); }
-    @Override public boolean getUseInitialStyleForInsertion() { return useInitialStyleForInsertion.get(); }
 
     private Optional<Tuple2<Codec<PS>, Codec<StyledSegment<SEG, S>>>> styleCodecs = Optional.empty();
     @Override public void setStyleCodecs(Codec<PS> paragraphStyleCodec, Codec<StyledSegment<SEG, S>> styledSegCodec) {
@@ -392,12 +380,8 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     }
 
     @Override public Var<Double> estimatedScrollXProperty() { return virtualFlow.estimatedScrollXProperty(); }
-    @Override public double getEstimatedScrollX() { return virtualFlow.estimatedScrollXProperty().getValue(); }
-    @Override public void setEstimatedScrollX(double value) { virtualFlow.estimatedScrollXProperty().setValue(value); }
 
     @Override public Var<Double> estimatedScrollYProperty() { return virtualFlow.estimatedScrollYProperty(); }
-    @Override public double getEstimatedScrollY() { return virtualFlow.estimatedScrollYProperty().getValue(); }
-    @Override public void setEstimatedScrollY(double value) { virtualFlow.estimatedScrollYProperty().setValue(value); }
 
     /* ********************************************************************** *
      *                                                                        *
@@ -407,52 +391,45 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      *                                                                        *
      * ********************************************************************** */
 
-    private final Property<Consumer<MouseEvent>> onOutsideSelectionMousePress = new SimpleObjectProperty<>(e -> {
+    private final ObjectProperty<Consumer<MouseEvent>> onOutsideSelectionMousePress = new SimpleObjectProperty<>(e -> {
         CharacterHit hit = hit(e.getX(), e.getY());
         moveTo(hit.getInsertionIndex(), SelectionPolicy.CLEAR);
     });
-    @Override public final void setOnOutsideSelectionMousePress(Consumer<MouseEvent> consumer) { onOutsideSelectionMousePress.setValue(consumer); }
-    @Override public final Consumer<MouseEvent> getOnOutsideSelectionMousePress() { return onOutsideSelectionMousePress.getValue(); }
+    @Override public final ObjectProperty<Consumer<MouseEvent>> onOutsideSelectionMousePressProperty() { return onOutsideSelectionMousePress; }
 
-    private final Property<Consumer<MouseEvent>> onInsideSelectionMousePressRelease = new SimpleObjectProperty<>(e -> {
+    private final ObjectProperty<Consumer<MouseEvent>> onInsideSelectionMousePressRelease = new SimpleObjectProperty<>(e -> {
         CharacterHit hit = hit(e.getX(), e.getY());
         moveTo(hit.getInsertionIndex(), SelectionPolicy.CLEAR);
     });
-    @Override public final void setOnInsideSelectionMousePressRelease(Consumer<MouseEvent> consumer) { onInsideSelectionMousePressRelease.setValue(consumer); }
-    @Override public final Consumer<MouseEvent> getOnInsideSelectionMousePressRelease() { return onInsideSelectionMousePressRelease.getValue(); }
+    @Override public final ObjectProperty<Consumer<MouseEvent>> onInsideSelectionMousePressReleaseProperty() { return onInsideSelectionMousePressRelease; }
 
-    private final Property<Consumer<Point2D>> onNewSelectionDrag = new SimpleObjectProperty<>(p -> {
+    private final ObjectProperty<Consumer<Point2D>> onNewSelectionDrag = new SimpleObjectProperty<>(p -> {
         CharacterHit hit = hit(p.getX(), p.getY());
         moveTo(hit.getInsertionIndex(), SelectionPolicy.ADJUST);
     });
-    @Override public final void setOnNewSelectionDrag(Consumer<Point2D> consumer) { onNewSelectionDrag.setValue(consumer); }
-    @Override public final Consumer<Point2D> getOnNewSelectionDrag() { return onNewSelectionDrag.getValue(); }
+    @Override public final ObjectProperty<Consumer<Point2D>> onNewSelectionDragProperty() { return onNewSelectionDrag; }
 
-    private final Property<Consumer<MouseEvent>> onNewSelectionDragEnd = new SimpleObjectProperty<>(e -> {
+    private final ObjectProperty<Consumer<MouseEvent>> onNewSelectionDragEnd = new SimpleObjectProperty<>(e -> {
         CharacterHit hit = hit(e.getX(), e.getY());
         moveTo(hit.getInsertionIndex(), SelectionPolicy.ADJUST);
     });
-    @Override public final void setOnNewSelectionDragEnd(Consumer<MouseEvent> consumer) { onNewSelectionDragEnd.setValue(consumer); }
-    @Override public final Consumer<MouseEvent> getOnNewSelectionDragEnd() { return onNewSelectionDragEnd.getValue(); }
+    @Override public final ObjectProperty<Consumer<MouseEvent>> onNewSelectionDragEndProperty() { return onNewSelectionDragEnd; }
 
-    private final Property<Consumer<Point2D>> onSelectionDrag = new SimpleObjectProperty<>(p -> {
+    private final ObjectProperty<Consumer<Point2D>> onSelectionDrag = new SimpleObjectProperty<>(p -> {
         CharacterHit hit = hit(p.getX(), p.getY());
         displaceCaret(hit.getInsertionIndex());
     });
-    @Override public final void setOnSelectionDrag(Consumer<Point2D> consumer) { onSelectionDrag.setValue(consumer); }
-    @Override public final Consumer<Point2D> getOnSelectionDrag() { return onSelectionDrag.getValue(); }
+    @Override public final ObjectProperty<Consumer<Point2D>> onSelectionDragProperty() { return onSelectionDrag; }
 
-    private final Property<Consumer<MouseEvent>> onSelectionDrop = new SimpleObjectProperty<>(e -> {
+    private final ObjectProperty<Consumer<MouseEvent>> onSelectionDrop = new SimpleObjectProperty<>(e -> {
         CharacterHit hit = hit(e.getX(), e.getY());
         moveSelectedText(hit.getInsertionIndex());
     });
-    @Override public final void setOnSelectionDrop(Consumer<MouseEvent> consumer) { onSelectionDrop.setValue(consumer); }
-    @Override public final Consumer<MouseEvent> getOnSelectionDrop() { return onSelectionDrop.getValue(); }
+    @Override public final ObjectProperty<Consumer<MouseEvent>> onSelectionDropProperty() { return onSelectionDrop; }
 
     // not a hook, but still plays a part in the default mouse behavior
     private final BooleanProperty autoScrollOnDragDesired = new SimpleBooleanProperty(true);
-    @Override public final void setAutoScrollOnDragDesired(boolean val) { autoScrollOnDragDesired.set(val); }
-    @Override public final boolean isAutoScrollOnDragDesired() { return autoScrollOnDragDesired.get(); }
+    @Override public final BooleanProperty autoScrollOnDragDesiredProperty() { return autoScrollOnDragDesired; }
 
     /* ********************************************************************** *
      *                                                                        *
@@ -465,7 +442,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      * ********************************************************************** */
 
     // text
-    @Override public final String getText() { return content.getText(); }
     @Override public final ObservableValue<String> textProperty() { return content.textProperty(); }
 
     // rich text
@@ -475,7 +451,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     @Override public final CaretSelectionBind<PS, SEG, S> getCaretSelectionBind() { return caretSelectionBind; }
 
     // length
-    @Override public final int getLength() { return content.getLength(); }
     @Override public final ObservableValue<Integer> lengthProperty() { return content.lengthProperty(); }
 
     // paragraphs
@@ -487,15 +462,12 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     // beingUpdated
     private final SuspendableNo beingUpdated = new SuspendableNo();
     @Override public final SuspendableNo beingUpdatedProperty() { return beingUpdated; }
-    @Override public final boolean isBeingUpdated() { return beingUpdated.get(); }
 
     // total width estimate
     @Override public Val<Double> totalWidthEstimateProperty() { return virtualFlow.totalWidthEstimateProperty(); }
-    @Override public double getTotalWidthEstimate() { return virtualFlow.totalWidthEstimateProperty().getValue(); }
 
     // total height estimate
     @Override public Val<Double> totalHeightEstimateProperty() { return virtualFlow.totalHeightEstimateProperty(); }
-    @Override public double getTotalHeightEstimate() { return virtualFlow.totalHeightEstimateProperty().getValue(); }
 
     /* ********************************************************************** *
      *                                                                        *
@@ -823,16 +795,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     }
 
     @Override
-    public final int firstVisibleParToAllParIndex() {
-        return visibleParToAllParIndex(0);
-    }
-
-    @Override
-    public final int lastVisibleParToAllParIndex() {
-        return visibleParToAllParIndex(visibleParagraphs.size() - 1);
-    }
-
-    @Override
     public CharacterHit hit(double x, double y) {
         // mouse position used, so account for padding
         double adjustedX = x - getInsets().getLeft();
@@ -1152,14 +1114,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     @Override
     public void displaceCaret(int pos) {
         caretSelectionBind.displaceCaret(pos);
-    }
-
-    @Override
-    public final void hideContextMenu() {
-        ContextMenu menu = getContextMenu();
-        if (menu != null && menu.isShowing()) {
-            menu.hide();
-        }
     }
 
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyleActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyleActions.java
@@ -17,9 +17,9 @@ public interface StyleActions<PS, S> {
      * inserted into this text area. When {@code false}, the style immediately
      * preceding the insertion position is used. Default value is {@code false}.
      */
-    boolean getUseInitialStyleForInsertion();
+    default boolean getUseInitialStyleForInsertion() { return useInitialStyleForInsertionProperty().get(); }
+    default void setUseInitialStyleForInsertion(boolean value) { useInitialStyleForInsertionProperty().set(value); }
     BooleanProperty useInitialStyleForInsertionProperty();
-    void setUseInitialStyleForInsertion(boolean value);
 
     /**
      * Style used by default when no other style is provided.

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextEditingArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextEditingArea.java
@@ -36,13 +36,13 @@ public interface TextEditingArea<PS, SEG, S> {
     /**
      * The number of characters in this text-editing area.
      */
-    int getLength();
+    default int getLength() { return lengthProperty().getValue(); }
     ObservableValue<Integer> lengthProperty();
 
     /**
      * Text content of this text-editing area.
      */
-    String getText();
+    default String getText() { return textProperty().getValue(); }
     ObservableValue<String> textProperty();
 
     /**

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
@@ -256,6 +256,11 @@ public interface ViewActions<PS, SEG, S> {
      * ********************************************************************** */
 
     /**
+     * Gets the height of the viewport and ignores the padding values added to the area.
+     */
+    public double getViewportHeight();
+
+    /**
      * Maps a paragraph index from {@link TextEditingArea#getParagraphs()} into the index system of
      * {@link #getVisibleParagraphs()}.
      */

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
@@ -384,6 +384,12 @@ public interface ViewActions<PS, SEG, S> {
     void showParagraphAtBottom(int paragraphIndex);
 
     /**
+     * Lays out the viewport so that the given bounds (according to the paragraph's coordinate system) within
+     * the given paragraph is visible in the viewport.
+     */
+    void showParagraphRegion(int paragraphIndex, Bounds region);
+
+    /**
      * If the caret is not visible within the area's view, the area will scroll so that caret
      * is visible in the next layout pass. Use this method when you wish to "follow the caret"
      * (i.e. auto-scroll to caret) after making a change (add/remove/modify area's segments).

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
@@ -1,6 +1,7 @@
 package org.fxmisc.richtext;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
@@ -34,8 +35,8 @@ public interface ViewActions<PS, SEG, S> {
      * Indicates whether this text area can be edited by the user.
      * Note that this property doesn't affect editing through the API.
      */
-    boolean isEditable();
-    void setEditable(boolean value);
+    default boolean isEditable() { return editableProperty().get(); }
+    default void setEditable(boolean value) { editableProperty().set(value); }
     BooleanProperty editableProperty();
 
     /**
@@ -43,8 +44,8 @@ public interface ViewActions<PS, SEG, S> {
      * then this property indicates whether the text should wrap
      * onto another line.
      */
-    boolean isWrapText();
-    void setWrapText(boolean value);
+    default boolean isWrapText() { return wrapTextProperty().get(); }
+    default void setWrapText(boolean value) { wrapTextProperty().set(value); }
     BooleanProperty wrapTextProperty();
 
     /**
@@ -55,8 +56,8 @@ public interface ViewActions<PS, SEG, S> {
      *
      * <p>Default value is {@code null}.
      */
-    Duration getMouseOverTextDelay();
-    void setMouseOverTextDelay(Duration delay);
+    default Duration getMouseOverTextDelay() { return mouseOverTextDelayProperty().get(); }
+    default void setMouseOverTextDelay(Duration delay) { mouseOverTextDelayProperty().set(delay); }
     ObjectProperty<Duration> mouseOverTextDelayProperty();
 
     /**
@@ -65,8 +66,9 @@ public interface ViewActions<PS, SEG, S> {
      * want this auto scroll feature to occur. This flag should be set to the correct value before the end of
      * the process InputMap.
      */
-    boolean isAutoScrollOnDragDesired();
-    void setAutoScrollOnDragDesired(boolean val);
+    default boolean isAutoScrollOnDragDesired() { return autoScrollOnDragDesiredProperty().get(); }
+    default void setAutoScrollOnDragDesired(boolean val) { autoScrollOnDragDesiredProperty().set(val); }
+    BooleanProperty autoScrollOnDragDesiredProperty();
 
     /**
      * Runs the consumer when the user pressed the mouse over unselected text within the area.
@@ -80,8 +82,9 @@ public interface ViewActions<PS, SEG, S> {
      *     }
      * </code></pre>.
      */
-    void setOnOutsideSelectionMousePress(Consumer<MouseEvent> consumer);
-    Consumer<MouseEvent> getOnOutsideSelectionMousePress();
+    default void setOnOutsideSelectionMousePress(Consumer<MouseEvent> consumer) { onOutsideSelectionMousePressProperty().set(consumer); }
+    default Consumer<MouseEvent> getOnOutsideSelectionMousePress() { return onOutsideSelectionMousePressProperty().get(); }
+    ObjectProperty<Consumer<MouseEvent>> onOutsideSelectionMousePressProperty();
 
     /**
      * Runs the consumer when the mouse is released in this scenario: the user has selected some text and then
@@ -98,8 +101,9 @@ public interface ViewActions<PS, SEG, S> {
      *     }
      * </code></pre>.
      */
-    Consumer<MouseEvent> getOnInsideSelectionMousePressRelease();
-    void setOnInsideSelectionMousePressRelease(Consumer<MouseEvent> consumer);
+    default Consumer<MouseEvent> getOnInsideSelectionMousePressRelease() { return onInsideSelectionMousePressReleaseProperty().get(); }
+    default void setOnInsideSelectionMousePressRelease(Consumer<MouseEvent> consumer) { onInsideSelectionMousePressReleaseProperty().set(consumer); }
+    ObjectProperty<Consumer<MouseEvent>> onInsideSelectionMousePressReleaseProperty();
 
     /**
      * Runs the consumer when the mouse is dragged in this scenario: the user has selected some text,
@@ -116,8 +120,9 @@ public interface ViewActions<PS, SEG, S> {
      *     }
      * </code></pre>.
      */
-    Consumer<Point2D> getOnNewSelectionDrag();
-    void setOnNewSelectionDrag(Consumer<Point2D> consumer);
+    default Consumer<Point2D> getOnNewSelectionDrag() { return onNewSelectionDragProperty().get(); }
+    default void setOnNewSelectionDrag(Consumer<Point2D> consumer) { onNewSelectionDragProperty().set(consumer); }
+    ObjectProperty<Consumer<Point2D>> onNewSelectionDragProperty();
 
     /**
      * Runs the consumer when the mouse is released in this scenario: the user has selected some text,
@@ -133,8 +138,9 @@ public interface ViewActions<PS, SEG, S> {
      *     }
      * </code></pre>.
      */
-    Consumer<MouseEvent> getOnNewSelectionDragEnd();
-    void setOnNewSelectionDragEnd(Consumer<MouseEvent> consumer);
+    default Consumer<MouseEvent> getOnNewSelectionDragEnd() { return onNewSelectionDragEndProperty().get(); }
+    default void setOnNewSelectionDragEnd(Consumer<MouseEvent> consumer) { onNewSelectionDragEndProperty().set(consumer); }
+    ObjectProperty<Consumer<MouseEvent>> onNewSelectionDragEndProperty();
 
     /**
      * Runs the consumer when the mouse is dragged in this scenario: the user has selected some text,
@@ -150,8 +156,9 @@ public interface ViewActions<PS, SEG, S> {
      *     }
      * </code></pre>.
      */
-    Consumer<Point2D> getOnSelectionDrag();
-    void setOnSelectionDrag(Consumer<Point2D> consumer);
+    default Consumer<Point2D> getOnSelectionDrag() { return onSelectionDragProperty().get(); }
+    default void setOnSelectionDrag(Consumer<Point2D> consumer) { onSelectionDragProperty().set(consumer); }
+    ObjectProperty<Consumer<Point2D>> onSelectionDragProperty();
 
     /**
      * Runs the consumer when the mouse is released in this scenario: the user has selected some text,
@@ -167,68 +174,65 @@ public interface ViewActions<PS, SEG, S> {
      *     }
      * </code></pre>.
      */
-    Consumer<MouseEvent> getOnSelectionDrop();
-    void setOnSelectionDrop(Consumer<MouseEvent> consumer);
+    default Consumer<MouseEvent> getOnSelectionDrop() { return onSelectionDropProperty().get(); }
+    default void setOnSelectionDrop(Consumer<MouseEvent> consumer) { onSelectionDropProperty().set(consumer); }
+    ObjectProperty<Consumer<MouseEvent>> onSelectionDropProperty();
 
     /**
      * Gets the function that maps a line index to a node that is positioned to the left of the first character
      * in a paragraph's text. Useful for toggle points or indicating the line's number via {@link LineNumberFactory}.
      */
-    IntFunction<? extends Node> getParagraphGraphicFactory();
-    void setParagraphGraphicFactory(IntFunction<? extends Node> factory);
+    default IntFunction<? extends Node> getParagraphGraphicFactory() { return paragraphGraphicFactoryProperty().get(); }
+    default void setParagraphGraphicFactory(IntFunction<? extends Node> factory) { paragraphGraphicFactoryProperty().set(factory); }
     ObjectProperty<IntFunction<? extends Node>> paragraphGraphicFactoryProperty();
 
     /** Gets the {@link ContextMenu} for the area, which is by default null. */
-    ContextMenu getContextMenu();
-    void setContextMenu(ContextMenu menu);
+    default ContextMenu getContextMenu() { return contextMenuObjectProperty().get(); }
+    default void setContextMenu(ContextMenu menu) { contextMenuObjectProperty().set(menu); }
     ObjectProperty<ContextMenu> contextMenuObjectProperty();
 
     /**
      * Gets the horizontal amount in pixels by which to offset the {@link #getContextMenu()} when it is shown,
      * which has a default value of 2.
      */
-    double getContextMenuXOffset();
-    void setContextMenuXOffset(double offset);
+    default double getContextMenuXOffset() { return contextMenuXOffsetProperty().get(); }
+    default void setContextMenuXOffset(double offset) { contextMenuXOffsetProperty().set(offset); }
+    DoubleProperty contextMenuXOffsetProperty();
 
     /**
      * Gets the vertical amount in pixels by which to offset the {@link #getContextMenu()} when it is shown,
      * which has a default value of 2.
      */
-    double getContextMenuYOffset();
-    void setContextMenuYOffset(double offset);
+    default double getContextMenuYOffset() { return contextMenuYOffsetProperty().get(); }
+    default void setContextMenuYOffset(double offset) { contextMenuYOffsetProperty().set(offset); }
+    DoubleProperty contextMenuYOffsetProperty();
 
     /**
-     * Gets the <em>estimated</em> scrollX value. This can be set in order to scroll the content.
+     * The <em>estimated</em> scrollX value. This can be set in order to scroll the content.
      * Value is only accurate when area does not wrap lines and uses the same font size
      * throughout the entire area.
      */
-    double getEstimatedScrollX();
-    void setEstimatedScrollX(double value);
     Var<Double> estimatedScrollXProperty();
 
     /**
-     * Gets the <em>estimated</em> scrollY value. This can be set in order to scroll the content.
+     * The <em>estimated</em> scrollY value. This can be set in order to scroll the content.
      * Value is only accurate when area does not wrap lines and uses the same font size
      * throughout the entire area.
      */
-    double getEstimatedScrollY();
-    void setEstimatedScrollY(double value);
     Var<Double> estimatedScrollYProperty();
 
     /**
-     * Gets the <em>estimated</em> width of the entire document. Accurate when area does not wrap lines and
+     * The <em>estimated</em> width of the entire document. Accurate when area does not wrap lines and
      * uses the same font size throughout the entire area. Value is only supposed to be <em>set</em> by
      * the skin, not the user.
      */
-    double getTotalWidthEstimate();
     Val<Double> totalWidthEstimateProperty();
 
     /**
-     * Gets the <em>estimated</em> height of the entire document. Accurate when area does not wrap lines and
+     * The <em>estimated</em> height of the entire document. Accurate when area does not wrap lines and
      * uses the same font size throughout the entire area. Value is only supposed to be <em>set</em> by
      * the skin, not the user.
      */
-    double getTotalHeightEstimate();
     Val<Double> totalHeightEstimateProperty();
 
     /**
@@ -275,12 +279,12 @@ public interface ViewActions<PS, SEG, S> {
     /**
      * Returns the index of the first visible paragraph in the index system of {@link TextEditingArea#getParagraphs()}.
      */
-    public int firstVisibleParToAllParIndex();
+    default int firstVisibleParToAllParIndex() { return visibleParToAllParIndex(0); }
 
     /**
      * Returns the index of the last visible paragraph in the index system of {@link TextEditingArea#getParagraphs()}.
      */
-    public int lastVisibleParToAllParIndex();
+    default int lastVisibleParToAllParIndex() { return visibleParToAllParIndex(getVisibleParagraphs().size() - 1); }
 
     /**
      * Helpful for determining which letter is at point x, y:
@@ -450,6 +454,11 @@ public interface ViewActions<PS, SEG, S> {
     /**
      * Hides the area's context menu if it is not {@code null} and it is {@link ContextMenu#isShowing() showing}.
      */
-    void hideContextMenu();
+    default void hideContextMenu() {
+        ContextMenu menu = getContextMenu();
+        if (menu != null && menu.isShowing()) {
+            menu.hide();
+        }
+    }
 
 }


### PR DESCRIPTION
Adds API to get the viewport's height and show a specific region of a given paragraph

Otherwise, cleans up the source code a bit more by
- removing unused methods
- using properties and default methods to reduce boilerplate
- put package-private and private methods in their own spots in the source code.