### PR TITLE
Add JabRef to the projects using RichTextFX

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Who uses RichTextFX?
 - [OmniEditor](https://github.com/giancosta86/OmniEditor), which is then used by [Chronos IDE](https://github.com/giancosta86/Chronos-IDE)
 - [JuliarFuture](https://juliar.org)
 - [BlueJ](https://www.bluej.org/)
+- [JabRef](http://www.jabref.org/)
 
 If you use RichTextFX in an interesting project, I would like to know!
 


### PR DESCRIPTION
JabRef is a bibliography management suite currently migrating to JavaFX. Our last published version uses RichTextFX.