### PR TITLE
Increase Mac build's TestFX setup timeout to 5 seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       # Java 8 Mac build
     - os: osx
       osx_image: xcode9
-      env: _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dtestfx.setup.timeout=2500"
+      env: _JAVA_OPTIONS="-Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k -Dtestfx.setup.timeout=5000"
 
 # enable Java 8u45+, see https://github.com/travis-ci/travis-ci/issues/4042
 addons:


### PR DESCRIPTION
Attempts to resolve #608