### PR TITLE
Allow initializing an [Editabled/ReadOnly]StyledDocument with content

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocument.java
@@ -13,6 +13,23 @@ package org.fxmisc.richtext.model;
 public final class GenericEditableStyledDocument<PS, SEG, S> extends GenericEditableStyledDocumentBase<PS, SEG, S>
         implements EditableStyledDocument<PS, SEG, S> {
 
+    /**
+     * Creates an {@link EditableStyledDocument} with the given document as its initial content
+     */
+    public GenericEditableStyledDocument(ReadOnlyStyledDocument<PS, SEG, S> initialContent) {
+        super(initialContent);
+    }
+
+    /**
+     * Creates an {@link EditableStyledDocument} with given paragraph as its initial content
+     */
+    public GenericEditableStyledDocument(Paragraph<PS, SEG, S> initialParagraph) {
+        super(initialParagraph);
+    }
+
+    /**
+     * Creates an empty {@link EditableStyledDocument}
+     */
     public GenericEditableStyledDocument(PS initialParagraphStyle, S initialStyle, SegmentOps<SEG, S> segmentOps) {
         super(initialParagraphStyle, initialStyle, segmentOps);
     }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocumentBase.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocumentBase.java
@@ -86,8 +86,11 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
     @Override public final SuspendableNo beingUpdatedProperty() { return beingUpdated; }
     @Override public final boolean isBeingUpdated() { return beingUpdated.get(); }
 
-    GenericEditableStyledDocumentBase(Paragraph<PS, SEG, S> initialParagraph) {
-        this.doc = new ReadOnlyStyledDocument<>(Collections.singletonList(initialParagraph));
+    /**
+     * Creates an {@link EditableStyledDocument} with the given document as its initial content
+     */
+    GenericEditableStyledDocumentBase(ReadOnlyStyledDocument<PS, SEG, S> initialContent) {
+        this.doc = initialContent;
 
         final Suspendable omniSuspendable = Suspendable.combine(
                 text,
@@ -102,9 +105,16 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
     }
 
     /**
+     * Creates an {@link EditableStyledDocument} with the given paragraph as its initial content
+     */
+    GenericEditableStyledDocumentBase(Paragraph<PS, SEG, S> initialParagraph) {
+        this(new ReadOnlyStyledDocument<>(Collections.singletonList(initialParagraph)));
+    }
+
+    /**
      * Creates an empty {@link EditableStyledDocument}
      */
-    public GenericEditableStyledDocumentBase(PS initialParagraphStyle, S initialStyle, SegmentOps<SEG, S> segmentOps) {
+    GenericEditableStyledDocumentBase(PS initialParagraphStyle, S initialStyle, SegmentOps<SEG, S> segmentOps) {
         this(new Paragraph<>(initialParagraphStyle, segmentOps, segmentOps.createEmptySeg(), initialStyle));
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/ReadOnlyStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/ReadOnlyStyledDocument.java
@@ -27,7 +27,8 @@ import org.reactfx.util.Tuple3;
 
 /**
  * An immutable implementation of {@link StyledDocument} that does not allow editing. For a {@link StyledDocument}
- * that can be edited, see {@link EditableStyledDocument}.
+ * that can be edited, see {@link EditableStyledDocument}. To create one, use its static factory
+ * "from"-prefixed methods or {@link ReadOnlyStyledDocumentBuilder}.
  *
  * @param <PS> The type of the paragraph style.
  * @param <SEG> The type of the segments in the paragraph (e.g. {@link String}).

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/ReadOnlyStyledDocumentBuilder.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/ReadOnlyStyledDocumentBuilder.java
@@ -1,0 +1,232 @@
+package org.fxmisc.richtext.model;
+
+import org.reactfx.util.Tuple2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Helper class via {@link #constructDocument(SegmentOps, Object, Consumer)} or one of its constructors and
+ * {@link #build()} for easily creating a {@link ReadOnlyStyledDocument} from a list
+ * of {@link Paragraph}s that is constructed via "addParagraph(s)" methods.
+ *
+ * @param <PS> the paragraph style type
+ * @param <SEG> the segment type
+ * @param <S> the segment style type
+ */
+public final class ReadOnlyStyledDocumentBuilder<PS, SEG, S> {
+
+    /**
+     * Constructs a list of paragraphs
+     *
+     * @param segmentOps the {@link SegmentOps} object to use for one of the {@link Paragraph}'s constructors
+     * @param defaultParagraphStyle the paragraph style object to use when it is not specified in the
+     *                              "addParagraph" methods
+     * @param configuration call the builder's {@link #addParagraph(Object, Object)} methods here
+     */
+    public static <PS, SEG, S> ReadOnlyStyledDocument<PS, SEG, S> constructDocument(
+            SegmentOps<SEG, S> segmentOps, PS defaultParagraphStyle,
+            Consumer<ReadOnlyStyledDocumentBuilder<PS, SEG, S>> configuration) {
+        ReadOnlyStyledDocumentBuilder<PS, SEG, S> builder = new ReadOnlyStyledDocumentBuilder<>(segmentOps, defaultParagraphStyle);
+        configuration.accept(builder);
+        return builder.build();
+    }
+
+    /**
+     * Constructs a list of paragraphs
+     *
+     * @param segmentOps the {@link SegmentOps} object to use for one of the {@link Paragraph}'s constructors
+     * @param defaultParagraphStyle the paragraph style object to use when it is not specified in the
+     *                              "addParagraph" methods
+     * @param initialCapacity the initial capaicty for the underlying {@link ArrayList}
+     * @param configuration call the builder's {@link #addParagraph(Object, Object)} methods here
+     */
+    public static <PS, SEG, S> ReadOnlyStyledDocument<PS, SEG, S> constructDocument(
+            SegmentOps<SEG, S> segmentOps, PS defaultParagraphStyle,
+            int initialCapacity, Consumer<ReadOnlyStyledDocumentBuilder<PS, SEG, S>> configuration) {
+        ReadOnlyStyledDocumentBuilder<PS, SEG, S> builder = new ReadOnlyStyledDocumentBuilder<>(segmentOps, defaultParagraphStyle, initialCapacity);
+        configuration.accept(builder);
+        return builder.build();
+    }
+
+    private final SegmentOps<SEG, S> segmentOps;
+    private final PS defaultParagraphStyle;
+    private final List<Paragraph<PS, SEG, S>> paragraphList;
+
+    private boolean alreadyCreated = false;
+
+    /**
+     * Creates a builder
+     *
+     * @param segmentOps the {@link SegmentOps} to use for each call to one of the {@link Paragraph}'s constructors.
+     * @param defaultParagraphStyle the default paragraph style to use when one is not specified in the
+     *                              "addParagraph"-prefixed methods
+     */
+    public ReadOnlyStyledDocumentBuilder(SegmentOps<SEG, S> segmentOps, PS defaultParagraphStyle) {
+        this(segmentOps, defaultParagraphStyle, new ArrayList<>());
+    }
+
+    /**
+     * Creates a builder
+     *
+     * @param segmentOps the {@link SegmentOps} to use for each call to one of the {@link Paragraph}'s constructors.
+     * @param defaultParagraphStyle the default paragraph style to use when one is not specified in the
+     *                              "addParagraph"-prefixed methods
+     * @param initialCapacity the initial capacity of the underlying {@link ArrayList}.
+     */
+    public ReadOnlyStyledDocumentBuilder(SegmentOps<SEG, S> segmentOps, PS defaultParagraphStyle, int initialCapacity) {
+        this(segmentOps, defaultParagraphStyle, new ArrayList<>(initialCapacity));
+    }
+
+    private ReadOnlyStyledDocumentBuilder(SegmentOps<SEG, S> segmentOps, PS defaultParagraphStyle, List<Paragraph<PS, SEG, S>> list) {
+        this.segmentOps = segmentOps;
+        this.defaultParagraphStyle = defaultParagraphStyle;
+        this.paragraphList = list;
+    }
+
+    /**
+     * Adds to the list a paragraph that is constructed using the list of {@link StyledSegment}s.
+     */
+    public ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraph(List<StyledSegment<SEG, S>> styledSegments) {
+        return addParagraph(styledSegments, null);
+    }
+
+    /**
+     * Adds to the list a paragraph that is constructed using the list of {@link StyledSegment}s.
+     */
+    public ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraph(List<StyledSegment<SEG, S>> styledSegments, PS paragraphStyle) {
+        return addPar(new Paragraph<>(argumentOrDefault(paragraphStyle), segmentOps, styledSegments));
+    }
+
+    /**
+     * Adds to the list  a paragraph that has only one segment that has the same given style throughout.
+     */
+    public ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraph(SEG segment, S style) {
+        return addParagraph(segment, style, null);
+    }
+
+    /**
+     * Adds to the list  a paragraph that has only one segment that has the same given style throughout.
+     */
+    public ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraph(SEG segment, S style, PS paragraphStyle) {
+        return addPar(new Paragraph<>(argumentOrDefault(paragraphStyle), segmentOps, segment, style));
+    }
+
+    /**
+     * Adds to the list  a paragraph that has only one segment but a number of different styles throughout that segment
+     */
+    public ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraph(SEG segment, StyleSpans<S> styles) {
+        return addParagraph(segment, styles, null);
+    }
+
+    /**
+     * Adds to the list  a paragraph that has only one segment but a number of different styles throughout that segment
+     */
+    public ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraph(SEG segment, StyleSpans<S> styles, PS paragraphStyle) {
+        return addPar(new Paragraph<>(argumentOrDefault(paragraphStyle), segmentOps, segment, styles));
+    }
+
+    /**
+     * Adds to the list a paragraph that has multiple segments with multiple styles throughout those segments
+     */
+    public ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraph(List<SEG> segments, StyleSpans<S> styles) {
+        return addParagraph(segments, styles, null);
+    }
+
+    /**
+     * Adds to the list a paragraph that has multiple segments with multiple styles throughout those segments
+     */
+    public ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraph(List<SEG> segments, StyleSpans<S> styles, PS paragraphStyle) {
+        return addPar(new Paragraph<>(argumentOrDefault(paragraphStyle), segmentOps, segments, styles));
+    }
+
+    /**
+     * Adds multiple paragraphs to the list, using the {@link #defaultParagraphStyle} for each paragraph. For
+     * more configuration on each paragraph's paragraph style, use {@link #addParagraphs0(List, StyleSpans)}
+     *
+     * @param listOfSegLists each item is the list of segments for a single paragraph
+     * @param entireDocumentStyleSpans style spans for the entire document. It's length should be equal to the length
+     *                                 of all the segments' length combined
+     */
+    public ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraphs(List<List<SEG>> listOfSegLists,
+                                 StyleSpans<S> entireDocumentStyleSpans) {
+        return addParagraphList(listOfSegLists, entireDocumentStyleSpans, ignore -> null, Function.identity());
+    }
+
+    /**
+     * Adds multiple paragraphs to the list, allowing one to specify each paragraph's paragraph style.
+     *
+     * @param paragraphArgList each item is a Tuple2 that represents the paragraph style and segment list
+     *                         for a single paragraph. If the paragraph style is {@code null},
+     *                         the {@link #defaultParagraphStyle} will be used instead.
+     * @param entireDocumentStyleSpans style spans for the entire document. It's length should be equal to the length
+     *                                 of all the segments' length combined
+     */
+    public ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraphs0(List<Tuple2<PS, List<SEG>>> paragraphArgList,
+                                 StyleSpans<S> entireDocumentStyleSpans) {
+        return addParagraphList(paragraphArgList, entireDocumentStyleSpans, Tuple2::get1, Tuple2::get2);
+    }
+
+    /**
+     * Returns an unmodifiable list of the constructed {@link Paragraph}s and ensures this builder cannot be used again.
+     */
+    public ReadOnlyStyledDocument<PS, SEG, S> build() {
+        ensureNotYetCreated();
+        if (paragraphList.isEmpty()) {
+            throw new IllegalStateException("Cannot build a ReadOnlyStyledDocument with an empty list of paragraphs!");
+        }
+        alreadyCreated = true;
+        return new ReadOnlyStyledDocument<>(paragraphList);
+    }
+
+    private <T> ReadOnlyStyledDocumentBuilder<PS, SEG, S> addParagraphList(List<T> paragraphContentList, StyleSpans<S> spansThroughoutDocument,
+                                       Function<T, PS> getStyle, Function<T, List<SEG>> getSegList) {
+        int docLength = paragraphContentList.stream()
+                .map(getSegList)
+                .flatMap(l -> l.stream().map(segmentOps::length))
+                .reduce(0, (a, b) -> a + b);
+
+        if (docLength != spansThroughoutDocument.length()) {
+            throw new IllegalArgumentException(String.format(
+                    "Document length does not equal style spans length! docLength=%s styleSpans' length=%s",
+                    docLength, spansThroughoutDocument.length()
+            ));
+        }
+
+        int styleOffset = 0;
+        for (T paragraphContent : paragraphContentList) {
+            PS paragraphStyle = argumentOrDefault(getStyle.apply(paragraphContent));
+            List<SEG> segList = getSegList.apply(paragraphContent);
+
+            int paragraphLength = segList.stream().mapToInt(segmentOps::length).sum();
+            int styleEnd = styleOffset + paragraphLength;
+            StyleSpans<S> spans = spansThroughoutDocument.subView(styleOffset, styleEnd);
+            addPar(new Paragraph<>(paragraphStyle, segmentOps, segList, spans));
+
+            styleOffset = styleEnd;
+        }
+        return this;
+    }
+
+    /**
+     * Returns the argument if it is not null; otherwise, returns {@link #defaultParagraphStyle}
+     */
+    private PS argumentOrDefault(PS paragraphStyle) {
+        return paragraphStyle != null ? paragraphStyle : defaultParagraphStyle;
+    }
+
+    private void ensureNotYetCreated() {
+        if (alreadyCreated) {
+            throw new IllegalStateException("This builder has already been used to create a list of Paragraphs. " +
+                    "One builder can only be used to build a single list. To create a new one, create a new builder");
+        }
+    }
+
+    private ReadOnlyStyledDocumentBuilder<PS, SEG, S> addPar(Paragraph<PS, SEG, S> paragraph) {
+        ensureNotYetCreated();
+        paragraphList.add(paragraph);
+        return this;
+    }
+}

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/SimpleEditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/SimpleEditableStyledDocument.java
@@ -31,4 +31,18 @@ public final class SimpleEditableStyledDocument<PS, S> extends GenericEditableSt
     public SimpleEditableStyledDocument(PS initialParagraphStyle, S initialTextStyle, SegmentOps<String, S> segOps) {
         super(initialParagraphStyle, initialTextStyle, segOps);
     }
+
+    /**
+     * Creates an {@link EditableStyledDocument} with given paragraph as its initial content
+     */
+    public SimpleEditableStyledDocument(Paragraph<PS, String, S> initialParagraph) {
+        super(initialParagraph);
+    }
+
+    /**
+     * Creates an {@link EditableStyledDocument} with the given document as its initial content
+     */
+    public SimpleEditableStyledDocument(ReadOnlyStyledDocument<PS, String, S> initialContent) {
+        super(initialContent);
+    }
 }

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/ReadOnlyStyledDocumentBuilderTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/ReadOnlyStyledDocumentBuilderTest.java
@@ -1,0 +1,205 @@
+package org.fxmisc.richtext.model;
+
+import org.junit.Test;
+import org.reactfx.util.Tuple2;
+import org.reactfx.util.Tuples;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ReadOnlyStyledDocumentBuilderTest {
+
+    private static final TextOps<String, String> SEGMENT_OPS = SegmentOps.styledTextOps();
+
+    @Test
+    public void adding_single_segment_single_style_single_paragraph_works() {
+        String text = "a";
+        String paragraphStyle = "ps style";
+        String textStyle = "seg style";
+
+        ReadOnlyStyledDocument<String, String, String> rosd = ReadOnlyStyledDocumentBuilder.constructDocument(
+                SEGMENT_OPS, paragraphStyle, builder -> builder.addParagraph(text, textStyle)
+        );
+
+        assertEquals(1, rosd.getParagraphCount());
+
+        Paragraph<String, String, String> p = rosd.getParagraph(0);
+        assertEquals(text, p.getText());
+        assertEquals(textStyle, p.getStyleSpans().getStyleSpan(0).getStyle());
+        assertEquals(paragraphStyle, p.getParagraphStyle());
+    }
+
+    @Test
+    public void adding_multiple_styled_segment_single_paragraph_works() {
+        String text = "a";
+        String textStyle = "a style";
+        String word = "word";
+        String wordStyle = "word style";
+        String paragraphStyle = "ps style";
+
+        List<StyledSegment<String, String>> styledSegList = new ArrayList<>(2);
+        styledSegList.addAll(Arrays.asList(
+                new StyledSegment<>(text, textStyle),
+                new StyledSegment<>(word, wordStyle)
+        ));
+
+        ReadOnlyStyledDocument<String, String, String> rosd = ReadOnlyStyledDocumentBuilder.constructDocument(
+                SEGMENT_OPS, paragraphStyle, builder -> builder.addParagraph(styledSegList)
+        );
+
+        assertEquals(1, rosd.getParagraphCount());
+
+        Paragraph<String, String, String> p = rosd.getParagraph(0);
+        assertEquals(1, p.getSegments().size());
+        assertEquals(text + word, p.getText());
+        assertEquals(textStyle, p.getStyleSpans().getStyleSpan(0).getStyle());
+        assertEquals(paragraphStyle, p.getParagraphStyle());
+    }
+
+    @Test
+    public void adding_single_segment_single_styleSpans_single_paragraph_works() {
+        String text = "a";
+        String paragraphStyle = "ps style";
+        String textStyle = "seg style";
+
+        StyleSpans<String> spans = StyleSpans.singleton(textStyle, text.length());
+
+        ReadOnlyStyledDocument<String, String, String> rosd = ReadOnlyStyledDocumentBuilder.constructDocument(
+                SEGMENT_OPS, paragraphStyle, builder -> builder.addParagraph(text, spans)
+        );
+
+        assertEquals(1, rosd.getParagraphCount());
+
+        Paragraph<String, String, String> p = rosd.getParagraph(0);
+        assertEquals(text, p.getText());
+        assertEquals(textStyle, p.getStyleSpans().getStyleSpan(0).getStyle());
+        assertEquals(paragraphStyle, p.getParagraphStyle());
+    }
+
+    @Test
+    public void adding_single_segment_list_single_styleSpans_single_paragraph_works() {
+        String text = "a";
+        String paragraphStyle = "ps style";
+        String textStyle = "seg style";
+
+        List<String> segmentList = Collections.singletonList(text);
+        StyleSpans<String> spans = StyleSpans.singleton(textStyle, text.length());
+
+        ReadOnlyStyledDocument<String, String, String> rosd = ReadOnlyStyledDocumentBuilder.constructDocument(
+                SEGMENT_OPS, paragraphStyle, builder -> builder.addParagraph(segmentList, spans)
+        );
+
+        assertEquals(1, rosd.getParagraphCount());
+
+        Paragraph<String, String, String> p = rosd.getParagraph(0);
+        assertEquals(text, p.getText());
+        assertEquals(textStyle, p.getStyleSpans().getStyleSpan(0).getStyle());
+        assertEquals(paragraphStyle, p.getParagraphStyle());
+    }
+
+    @Test
+    public void adding_single_segment_single_style_without_par_style_paragraph_list_works() {
+        String text = "a";
+        String paragraphStyle = "ps style";
+        String textStyle = "seg style";
+
+        List<List<String>> singletonList = Collections.singletonList(
+                Collections.singletonList(text)
+        );
+        StyleSpans<String> spans = StyleSpans.singleton(textStyle, text.length());
+
+        ReadOnlyStyledDocument<String, String, String> rosd = ReadOnlyStyledDocumentBuilder.constructDocument(
+                SEGMENT_OPS, paragraphStyle, builder -> builder.addParagraphs(singletonList, spans)
+        );
+
+        assertEquals(1, rosd.getParagraphCount());
+
+        Paragraph<String, String, String> p = rosd.getParagraph(0);
+        assertEquals(text, p.getText());
+        assertEquals(textStyle, p.getStyleSpans().getStyleSpan(0).getStyle());
+        assertEquals(paragraphStyle, p.getParagraphStyle());
+    }
+
+    @Test
+    public void adding_single_segment_single_style_with_par_style_paragraph_list_works() {
+        String text = "a";
+        String paragraphStyle = "ps style";
+        String textStyle = "seg style";
+
+        List<Tuple2<String, List<String>>> singletonList = Collections.singletonList(
+                Tuples.t(paragraphStyle, Collections.singletonList(text))
+        );
+        StyleSpans<String> spans = StyleSpans.singleton(textStyle, text.length());
+
+        ReadOnlyStyledDocument<String, String, String> rosd = ReadOnlyStyledDocumentBuilder.constructDocument(
+                SEGMENT_OPS, paragraphStyle, builder -> builder.addParagraphs0(singletonList, spans)
+        );
+
+        assertEquals(1, rosd.getParagraphCount());
+
+        Paragraph<String, String, String> p = rosd.getParagraph(0);
+        assertEquals(text, p.getText());
+        assertEquals(textStyle, p.getStyleSpans().getStyleSpan(0).getStyle());
+        assertEquals(paragraphStyle, p.getParagraphStyle());
+    }
+
+    @Test
+    public void attempting_to_build_ReadOnlyStyledDocument_using_empty_paragraph_list_throws_exception() {
+        ReadOnlyStyledDocumentBuilder<String, String, String> builder = new ReadOnlyStyledDocumentBuilder<>(
+                SEGMENT_OPS, "ps style"
+        );
+        try {
+            builder.build();
+            fail("Cannot build a ReadOnlyStyledDocument with an empty list of paragraphs");
+        } catch (IllegalStateException e) {
+            // cannot build a ROSD with an empty list of paragraphs
+        }
+    }
+
+    @Test
+    public void using_a_builder_more_than_once_throws_exception() {
+        ReadOnlyStyledDocumentBuilder<String, String, String> builder = new ReadOnlyStyledDocumentBuilder<>(
+                SEGMENT_OPS, "ps style"
+        );
+        builder.addParagraph("text", "text style");
+        builder.build();
+        try {
+            builder.build();
+            fail("Cannot use a single ReadOnlyStyledDocumentBuilder to build multiple ROSDs.");
+        } catch (IllegalStateException e) {
+            // each builder has a one-time usage
+        }
+    }
+
+    @Test
+    public void creating_paragraph_with_different_segment_and_style_length_throws_exception() {
+        String text = "a";
+        int textStyle = 1;
+
+        List<List<String>> singletonList = Collections.singletonList(
+                Collections.singletonList(text)
+        );
+        int segmentLength = text.length();
+        int spanLength = segmentLength + 10;
+        StyleSpans<Integer> spans = StyleSpans.singleton(textStyle, spanLength);
+
+        ReadOnlyStyledDocumentBuilder<Integer, String, Integer> builder = new ReadOnlyStyledDocumentBuilder<>(
+                SegmentOps.styledTextOps(), 0
+        );
+
+        assertTrue(segmentLength != spanLength);
+
+        try {
+            builder.addParagraphs(singletonList, spans);
+            fail("Style spans length must equal the length of all segments");
+        } catch (IllegalArgumentException e) {
+            // style spans' length is more than the length of all segments
+        }
+    }
+}


### PR DESCRIPTION
Resolves #646 

No longer adddresses #644

Before this, the initial document must always be empty