### PR TITLE
Corrected misspelled read-only pseudo class

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -294,7 +294,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      */
     public static final IndexRange EMPTY_RANGE = new IndexRange(0, 0);
 
-    private static final PseudoClass READ_ONLY = PseudoClass.getPseudoClass("read-only");
+    private static final PseudoClass READ_ONLY = PseudoClass.getPseudoClass("readonly");
     private static final PseudoClass HAS_CARET = PseudoClass.getPseudoClass("has-caret");
     private static final PseudoClass FIRST_PAR = PseudoClass.getPseudoClass("first-paragraph");
     private static final PseudoClass LAST_PAR  = PseudoClass.getPseudoClass("last-paragraph");


### PR DESCRIPTION
Fix for #650 (Read only pseudo class is misspelled in GenericStyledArea)