### PR TITLE
RFE implementation for #653 / #655

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/FxmlTest.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/FxmlTest.java
@@ -1,0 +1,15 @@
+package org.fxmisc.richtext.api;
+
+import javafx.fxml.FXML;
+import javafx.scene.input.MouseEvent;
+
+public class FxmlTest
+{
+    @FXML void testWithMouseEvent( MouseEvent ME ) {
+        // We're just checking that a property can be set in FXML
+    }
+
+    @FXML void testWithOutMouseEvent() {
+        // We're just checking that a property can be set in FXML
+    }
+}

--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/FxmlTester.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/FxmlTester.java
@@ -5,6 +5,7 @@ import javafx.stage.Stage;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.LoadException;
 import org.fxmisc.richtext.RichTextFXTestBase;
+import org.fxmisc.richtext.StyleClassedTextArea;
 import org.junit.Test;
 
 public class FxmlTester extends RichTextFXTestBase {
@@ -15,14 +16,21 @@ public class FxmlTester extends RichTextFXTestBase {
     }
 
     @Test
-	public void test_fxml_construction_of_area() throws IOException, LoadException
-	{
-        // FxmlTest.fxml is located in resources folder:
-        // src/integrationTest/resources/org/fxmisc/richtext/api/
-		Object obj = FXMLLoader.load( getClass().getResource( "FxmlTest.fxml" ) );
-        // FXMLLoader will throw a LoadException if any properties failed to be set,
-        // so if obj is not null then all properties are guaranteed to have been set.
-        org.junit.Assert.assertNotNull( obj );
+    public void test_fxml_construction_of_area() throws IOException, LoadException
+    {
+        // FxmlTest.fxml is located in resources folder: src/integrationTest/resources/org/fxmisc/richtext/api/
+        FXMLLoader fxml = new FXMLLoader( getClass().getResource( "FxmlTest.fxml" ) );
+        StyleClassedTextArea area = (StyleClassedTextArea) fxml.load();
+        // fxml.load() will throw a LoadException if any properties failed to be set,
+        // so if 'area' is not null then all properties are guaranteed to have been set.
+        org.junit.Assert.assertNotNull( area );
+        
+        FxmlTest ctrl = fxml.getController();
+        // Check that the controller was loaded and that it has the relevant
+        // test methods which are referenced in the loaded fxml file.
+        org.junit.Assert.assertNotNull( ctrl );
+        ctrl.testWithMouseEvent( null );
+        ctrl.testWithOutMouseEvent();
     }
 
 }

--- a/richtextfx/src/integrationTest/resources/org/fxmisc/richtext/api/FxmlTest.fxml
+++ b/richtextfx/src/integrationTest/resources/org/fxmisc/richtext/api/FxmlTest.fxml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.layout.VBox?>
 <?import org.fxmisc.richtext.StyleClassedTextArea?>
 <?import javafx.scene.control.ContextMenu?>
 <?import javafx.scene.control.MenuItem?>
 
-<VBox xmlns:fx="http://javafx.com/fxml/1">
-    <StyleClassedTextArea editable="true" wrapText="true" autoScrollOnDragDesired="true"
-                          contextMenuXOffset="12.0" contextMenuYOffset="34.0" >
-        <contextMenu>
-            <ContextMenu>
-                <items><MenuItem text="Test Item" /></items>
-            </ContextMenu>
-        </contextMenu>
-    </StyleClassedTextArea>
-</VBox>
-
+<StyleClassedTextArea xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.fxmisc.richtext.api.FxmlTest"
+    editable="true" wrapText="true" autoScrollOnDragDesired="true"
+    onInsideSelectionMousePressReleased="#testWithMouseEvent" onOutsideSelectionMousePressed="#testWithOutMouseEvent" 
+    onNewSelectionDragFinished="#testWithMouseEvent" onSelectionDropped="#testWithOutMouseEvent"
+    contextMenuXOffset="12.0" contextMenuYOffset="34.0" >
+    <contextMenu>
+        <ContextMenu>
+            <items><MenuItem text="Test Item" /></items>
+        </ContextMenu>
+    </contextMenu>
+</StyleClassedTextArea>

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -35,6 +35,7 @@ import javafx.css.StyleConverter;
 import javafx.css.Styleable;
 import javafx.css.StyleableObjectProperty;
 import javafx.event.Event;
+import javafx.event.EventHandler;
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
@@ -182,8 +183,8 @@ import org.reactfx.value.Var;
  *     <li>
  *         <em>First (1 click count) Primary Button Mouse Pressed Events:</em>
  *         (<code>EventPattern.mousePressed(MouseButton.PRIMARY).onlyIf(e -&gt; e.getClickCount() == 1)</code>).
- *         Do not override. Instead, use {@link #onOutsideSelectionMousePress},
- *         {@link #onInsideSelectionMousePressRelease}, or see next item.
+ *         Do not override. Instead, use {@link #onOutsideSelectionMousePressed},
+ *         {@link #onInsideSelectionMousePressReleased}, or see next item.
  *     </li>
  *     <li>(
  *         <em>All Other Mouse Pressed Events (e.g., Primary with 2+ click count):</em>
@@ -223,7 +224,7 @@ import org.reactfx.value.Var;
  *     <li>
  *         <em>Primary-Button-only Mouse Released Events:</em>
  *         (<code>EventPattern.mouseReleased().onlyIf(e -&gt; e.getButton() == MouseButton.PRIMARY &amp;&amp; !e.isMiddleButtonDown() &amp;&amp; !e.isSecondaryButtonDown())</code>).
- *         Do not override. Instead, use {@link #onNewSelectionDragEnd}, {@link #onSelectionDrop}, or see next item.
+ *         Do not override. Instead, use {@link #onNewSelectionDragFinished}, {@link #onSelectionDropped}, or see next item.
  *     </li>
  *     <li>
  *         <em>All other Mouse Released Events:</em>
@@ -348,7 +349,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     // Don't remove as FXMLLoader doesn't recognise default methods !
     @Override public void setWrapText(boolean value) { wrapText.set(value); }
     @Override public boolean isWrapText() { return wrapText.get(); }
-    
+
     // undo manager
     private UndoManager undoManager;
     @Override public UndoManager getUndoManager() { return undoManager; }
@@ -406,17 +407,19 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      *                                                                        *
      * ********************************************************************** */
 
-    private final ObjectProperty<Consumer<MouseEvent>> onOutsideSelectionMousePress = new SimpleObjectProperty<>(e -> {
-        CharacterHit hit = hit(e.getX(), e.getY());
-        moveTo(hit.getInsertionIndex(), SelectionPolicy.CLEAR);
+    @Override public final EventHandler<MouseEvent> getOnOutsideSelectionMousePressed() { return onOutsideSelectionMousePressed.get(); }
+    @Override public final void setOnOutsideSelectionMousePressed(EventHandler<MouseEvent> handler) { onOutsideSelectionMousePressed.set( handler ); }
+    @Override public final ObjectProperty<EventHandler<MouseEvent>> onOutsideSelectionMousePressedProperty() { return onOutsideSelectionMousePressed; }
+    private final ObjectProperty<EventHandler<MouseEvent>> onOutsideSelectionMousePressed = new SimpleObjectProperty<>( e -> {
+    	onOutsideSelectionMousePressProperty().get().accept(e);
     });
-    @Override public final ObjectProperty<Consumer<MouseEvent>> onOutsideSelectionMousePressProperty() { return onOutsideSelectionMousePress; }
 
-    private final ObjectProperty<Consumer<MouseEvent>> onInsideSelectionMousePressRelease = new SimpleObjectProperty<>(e -> {
-        CharacterHit hit = hit(e.getX(), e.getY());
-        moveTo(hit.getInsertionIndex(), SelectionPolicy.CLEAR);
+    @Override public final EventHandler<MouseEvent> getOnInsideSelectionMousePressReleased() { return onInsideSelectionMousePressReleased.get(); }
+    @Override public final void setOnInsideSelectionMousePressReleased(EventHandler<MouseEvent> handler) { onInsideSelectionMousePressReleased.set( handler ); }
+    @Override public final ObjectProperty<EventHandler<MouseEvent>> onInsideSelectionMousePressReleasedProperty() { return onInsideSelectionMousePressReleased; }
+    private final ObjectProperty<EventHandler<MouseEvent>> onInsideSelectionMousePressReleased = new SimpleObjectProperty<>( e -> {
+    	onInsideSelectionMousePressReleaseProperty().get().accept(e);
     });
-    @Override public final ObjectProperty<Consumer<MouseEvent>> onInsideSelectionMousePressReleaseProperty() { return onInsideSelectionMousePressRelease; }
 
     private final ObjectProperty<Consumer<Point2D>> onNewSelectionDrag = new SimpleObjectProperty<>(p -> {
         CharacterHit hit = hit(p.getX(), p.getY());
@@ -424,11 +427,13 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     });
     @Override public final ObjectProperty<Consumer<Point2D>> onNewSelectionDragProperty() { return onNewSelectionDrag; }
 
-    private final ObjectProperty<Consumer<MouseEvent>> onNewSelectionDragEnd = new SimpleObjectProperty<>(e -> {
+    @Override public final EventHandler<MouseEvent> getOnNewSelectionDragFinished() { return onNewSelectionDragFinished.get(); }
+    @Override public final void setOnNewSelectionDragFinished(EventHandler<MouseEvent> handler) { onNewSelectionDragFinished.set( handler ); }
+    @Override public final ObjectProperty<EventHandler<MouseEvent>> onNewSelectionDragFinishedProperty() { return onNewSelectionDragFinished; }
+    private final ObjectProperty<EventHandler<MouseEvent>> onNewSelectionDragFinished = new SimpleObjectProperty<>( e -> {
         CharacterHit hit = hit(e.getX(), e.getY());
         moveTo(hit.getInsertionIndex(), SelectionPolicy.ADJUST);
     });
-    @Override public final ObjectProperty<Consumer<MouseEvent>> onNewSelectionDragEndProperty() { return onNewSelectionDragEnd; }
 
     private final ObjectProperty<Consumer<Point2D>> onSelectionDrag = new SimpleObjectProperty<>(p -> {
         CharacterHit hit = hit(p.getX(), p.getY());
@@ -436,11 +441,12 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     });
     @Override public final ObjectProperty<Consumer<Point2D>> onSelectionDragProperty() { return onSelectionDrag; }
 
-    private final ObjectProperty<Consumer<MouseEvent>> onSelectionDrop = new SimpleObjectProperty<>(e -> {
-        CharacterHit hit = hit(e.getX(), e.getY());
-        moveSelectedText(hit.getInsertionIndex());
+    @Override public final EventHandler<MouseEvent> getOnSelectionDropped() { return onSelectionDropped.get(); }
+    @Override public final void setOnSelectionDropped(EventHandler<MouseEvent> handler) { onSelectionDropped.set( handler ); }
+    @Override public final ObjectProperty<EventHandler<MouseEvent>> onSelectionDroppedProperty() { return onSelectionDropped; }
+    private final ObjectProperty<EventHandler<MouseEvent>> onSelectionDropped = new SimpleObjectProperty<>( e -> {
+    	onSelectionDropProperty().get().accept(e);
     });
-    @Override public final ObjectProperty<Consumer<MouseEvent>> onSelectionDropProperty() { return onSelectionDrop; }
 
     // not a hook, but still plays a part in the default mouse behavior
     private final BooleanProperty autoScrollOnDragDesired = new SimpleBooleanProperty(true);
@@ -1483,4 +1489,37 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         return CSS_META_DATA_LIST;
     }
 
+
+    // Note: this code should be moved to `onOutsideSelectionMousePressed` property
+    // in the next major release before removing this deprecated field
+    @Deprecated private final ObjectProperty<Consumer<MouseEvent>> onOutsideSelectionMousePress = new SimpleObjectProperty<>( e -> {
+        CharacterHit hit = hit(e.getX(), e.getY());
+        moveTo(hit.getInsertionIndex(), SelectionPolicy.CLEAR);
+    });
+    @Deprecated
+    @Override public final ObjectProperty<Consumer<MouseEvent>> onOutsideSelectionMousePressProperty() {
+    	return onOutsideSelectionMousePress;
+    }
+
+    // Note: this code should be moved to `onInsideSelectionMouseReleased` property
+    // in the next major release before removing this deprecated field
+    @Deprecated private final ObjectProperty<Consumer<MouseEvent>> onInsideSelectionMousePressRelease = new SimpleObjectProperty<>( e -> {
+        CharacterHit hit = hit(e.getX(), e.getY());
+        moveTo(hit.getInsertionIndex(), SelectionPolicy.CLEAR);
+    });
+    @Deprecated
+    @Override public final ObjectProperty<Consumer<MouseEvent>> onInsideSelectionMousePressReleaseProperty() {
+    	return onInsideSelectionMousePressRelease;
+    }
+
+    // Note: this code should be moved to `onSelectionDropped` property
+    // in the next major release before removing this deprecated field
+    @Deprecated private final ObjectProperty<Consumer<MouseEvent>> onSelectionDrop = new SimpleObjectProperty<>( e -> {
+        CharacterHit hit = hit(e.getX(), e.getY());
+        moveSelectedText(hit.getInsertionIndex());
+    });
+    @Deprecated
+    @Override public final ObjectProperty<Consumer<MouseEvent>> onSelectionDropProperty() {
+    	return onSelectionDrop;
+    }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledAreaBehavior.java
@@ -476,7 +476,7 @@ class GenericStyledAreaBehavior {
             dragSelection = DragState.POTENTIAL_DRAG;
         } else {
             dragSelection = DragState.NO_DRAG;
-            view.getOnOutsideSelectionMousePress().accept(e);
+            view.getOnOutsideSelectionMousePressed().handle(e);
         }
     }
 
@@ -534,9 +534,9 @@ class GenericStyledAreaBehavior {
         switch(dragSelection) {
             case POTENTIAL_DRAG:
                 // selection was not dragged, but clicked
-                view.getOnInsideSelectionMousePressRelease().accept(e);
+                view.getOnInsideSelectionMousePressReleased().handle(e);
             case DRAG:
-                view.getOnSelectionDrop().accept(e);
+                view.getOnSelectionDropped().handle(e);
             case NO_DRAG:
                 // do nothing, caret already repositioned in "handle[Number]Press(MouseEvent)"
         }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledAreaBehavior.java
@@ -270,9 +270,14 @@ class GenericStyledAreaBehavior {
     private final GenericStyledArea<?, ?, ?> view;
 
     /**
-     * Indicates whether selection is being dragged by the user.
+     * Indicates whether an existing selection is being dragged by the user.
      */
     private DragState dragSelection = DragState.NO_DRAG;
+
+    /**
+     * Indicates whether a new selection is being made by the user.
+     */
+    private DragState dragNewSelection = DragState.NO_DRAG;
 
     private final Var<Point2D> autoscrollTo = Var.newSimpleVar(null);
 
@@ -474,8 +479,10 @@ class GenericStyledAreaBehavior {
                 hit.getCharacterIndex().getAsInt() < selection.getEnd()) {
             // press inside selection
             dragSelection = DragState.POTENTIAL_DRAG;
+            dragNewSelection = DragState.NO_DRAG;
         } else {
             dragSelection = DragState.NO_DRAG;
+            dragNewSelection = DragState.NO_DRAG;
             view.getOnOutsideSelectionMousePressed().handle(e);
         }
     }
@@ -492,6 +499,7 @@ class GenericStyledAreaBehavior {
         if (dragSelection == DragState.POTENTIAL_DRAG) {
             dragSelection = DragState.DRAG;
         }
+        else dragNewSelection = DragState.DRAG;
     }
 
     private Result processPrimaryOnlyMouseDragged(MouseEvent e) {
@@ -537,9 +545,12 @@ class GenericStyledAreaBehavior {
                 view.getOnInsideSelectionMousePressReleased().handle(e);
             case DRAG:
                 view.getOnSelectionDropped().handle(e);
-            case NO_DRAG:
-                // do nothing, caret already repositioned in "handle[Number]Press(MouseEvent)"
+                break;
+            case NO_DRAG: if ( dragNewSelection == DragState.DRAG ) {
+                view.getOnNewSelectionDragFinished().handle(e);
+            }
         }
+        dragNewSelection = DragState.NO_DRAG;
         dragSelection = DragState.NO_DRAG;
 
         return Result.PROCEED;

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
@@ -3,12 +3,14 @@ package org.fxmisc.richtext;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.event.EventHandler;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.text.TextFlow;
+
 import org.fxmisc.richtext.model.Paragraph;
 import org.fxmisc.richtext.event.MouseOverTextEvent;
 import org.reactfx.EventStream;
@@ -71,7 +73,7 @@ public interface ViewActions<PS, SEG, S> {
     BooleanProperty autoScrollOnDragDesiredProperty();
 
     /**
-     * Runs the consumer when the user pressed the mouse over unselected text within the area.
+     * Runs the EventHandler when the user pressed the mouse over unselected text within the area.
      *
      * <p>By default, this will {@link NavigationActions#moveTo(int) move the caret} to the position where
      * the mouse was pressed and clear out any selection via the code:
@@ -82,12 +84,12 @@ public interface ViewActions<PS, SEG, S> {
      *     }
      * </code></pre>.
      */
-    default void setOnOutsideSelectionMousePress(Consumer<MouseEvent> consumer) { onOutsideSelectionMousePressProperty().set(consumer); }
-    default Consumer<MouseEvent> getOnOutsideSelectionMousePress() { return onOutsideSelectionMousePressProperty().get(); }
-    ObjectProperty<Consumer<MouseEvent>> onOutsideSelectionMousePressProperty();
+    void setOnOutsideSelectionMousePressed(EventHandler<MouseEvent> handler);
+    ObjectProperty<EventHandler<MouseEvent>> onOutsideSelectionMousePressedProperty();
+    EventHandler<MouseEvent> getOnOutsideSelectionMousePressed();
 
     /**
-     * Runs the consumer when the mouse is released in this scenario: the user has selected some text and then
+     * Runs the EventHandler when the mouse is released in this scenario: the user has selected some text and then
      * "clicked" the mouse somewhere in that selection (the use pressed the mouse, did not drag it,
      * and released the mouse). <em>Note:</em> this consumer is run on {@link MouseEvent#MOUSE_RELEASED},
      * not {@link MouseEvent#MOUSE_CLICKED}.
@@ -101,9 +103,9 @@ public interface ViewActions<PS, SEG, S> {
      *     }
      * </code></pre>.
      */
-    default Consumer<MouseEvent> getOnInsideSelectionMousePressRelease() { return onInsideSelectionMousePressReleaseProperty().get(); }
-    default void setOnInsideSelectionMousePressRelease(Consumer<MouseEvent> consumer) { onInsideSelectionMousePressReleaseProperty().set(consumer); }
-    ObjectProperty<Consumer<MouseEvent>> onInsideSelectionMousePressReleaseProperty();
+    void setOnInsideSelectionMousePressReleased(EventHandler<MouseEvent> handler);
+    ObjectProperty<EventHandler<MouseEvent>> onInsideSelectionMousePressReleasedProperty();
+    EventHandler<MouseEvent> getOnInsideSelectionMousePressReleased();
 
     /**
      * Runs the consumer when the mouse is dragged in this scenario: the user has selected some text,
@@ -125,7 +127,7 @@ public interface ViewActions<PS, SEG, S> {
     ObjectProperty<Consumer<Point2D>> onNewSelectionDragProperty();
 
     /**
-     * Runs the consumer when the mouse is released in this scenario: the user has selected some text,
+     * Runs the EventHandler when the mouse is released in this scenario: the user has selected some text,
      * pressed the mouse on top of the selection, dragged it to a new location within the area,
      * and released the mouse.
      *
@@ -138,9 +140,9 @@ public interface ViewActions<PS, SEG, S> {
      *     }
      * </code></pre>.
      */
-    default Consumer<MouseEvent> getOnNewSelectionDragEnd() { return onNewSelectionDragEndProperty().get(); }
-    default void setOnNewSelectionDragEnd(Consumer<MouseEvent> consumer) { onNewSelectionDragEndProperty().set(consumer); }
-    ObjectProperty<Consumer<MouseEvent>> onNewSelectionDragEndProperty();
+    void setOnNewSelectionDragFinished(EventHandler<MouseEvent> handler);
+    ObjectProperty<EventHandler<MouseEvent>> onNewSelectionDragFinishedProperty();
+    EventHandler<MouseEvent> getOnNewSelectionDragFinished();
 
     /**
      * Runs the consumer when the mouse is dragged in this scenario: the user has selected some text,
@@ -161,7 +163,7 @@ public interface ViewActions<PS, SEG, S> {
     ObjectProperty<Consumer<Point2D>> onSelectionDragProperty();
 
     /**
-     * Runs the consumer when the mouse is released in this scenario: the user has selected some text,
+     * Runs the EventHandler when the mouse is released in this scenario: the user has selected some text,
      * pressed the mouse on top of the selection, dragged it to a new location within the area,
      * and released the mouse within the area.
      *
@@ -174,9 +176,9 @@ public interface ViewActions<PS, SEG, S> {
      *     }
      * </code></pre>.
      */
-    default Consumer<MouseEvent> getOnSelectionDrop() { return onSelectionDropProperty().get(); }
-    default void setOnSelectionDrop(Consumer<MouseEvent> consumer) { onSelectionDropProperty().set(consumer); }
-    ObjectProperty<Consumer<MouseEvent>> onSelectionDropProperty();
+    void setOnSelectionDropped(EventHandler<MouseEvent> handler);
+    ObjectProperty<EventHandler<MouseEvent>> onSelectionDroppedProperty();
+    EventHandler<MouseEvent> getOnSelectionDropped();
 
     /**
      * Gets the function that maps a line index to a node that is positioned to the left of the first character
@@ -460,5 +462,26 @@ public interface ViewActions<PS, SEG, S> {
             menu.hide();
         }
     }
+
+    /** Use setOnOutsideSelectionMousePress<u>ed</u>(<i>EventHandler&gt;MouseEvent&lt;</i>) instead, which is FXML compatible */
+    @Deprecated default void setOnOutsideSelectionMousePress(Consumer<MouseEvent> consumer) { onOutsideSelectionMousePressProperty().set(consumer); }
+    /** Use getOnOutsideSelectionMousePress<u>ed</u>() instead */
+    @Deprecated default Consumer<MouseEvent> getOnOutsideSelectionMousePress() { return onOutsideSelectionMousePressProperty().get(); }
+    /** Use onOutsideSelectionMousePress<u>ed</u>Property() instead */
+    @Deprecated ObjectProperty<Consumer<MouseEvent>> onOutsideSelectionMousePressProperty();
+
+    /** Use getOnInsideSelectionMousePressRelease<u>d</u>() instead */
+    @Deprecated default Consumer<MouseEvent> getOnInsideSelectionMousePressRelease() { return onInsideSelectionMousePressReleaseProperty().get(); }
+    /** Use setOnInsideSelectionMousePressRelease<u>d</u>(<i>EventHandler&gt;MouseEvent&lt;</i>) instead, which is FXML compatible */
+    @Deprecated default void setOnInsideSelectionMousePressRelease(Consumer<MouseEvent> consumer) { onInsideSelectionMousePressReleaseProperty().set(consumer); }
+    /** Use onInsideSelectionMousePressRelease<u>d</u>Property() instead */
+    @Deprecated ObjectProperty<Consumer<MouseEvent>> onInsideSelectionMousePressReleaseProperty();
+
+    /** Use getOnSelectionDrop<u>ped</u>() instead */
+    @Deprecated default Consumer<MouseEvent> getOnSelectionDrop() { return onSelectionDropProperty().get(); }
+    /** Use setOnSelectionDrop<u>ped</u>(<i>EventHandler&gt;MouseEvent&lt;</i>) instead, which is FXML compatible */
+    @Deprecated default void setOnSelectionDrop(Consumer<MouseEvent> consumer) { onSelectionDropProperty().set(consumer); }
+    /** Use onSelectionDrop<u>ped</u>Property() instead */
+    @Deprecated ObjectProperty<Consumer<MouseEvent>> onSelectionDropProperty();
 
 }


### PR DESCRIPTION
RFE implementation for #655
The methods in `ViewActions` related to the following have been @**Deprecated**:

> onOutsideSelectionMousePress
> onInsideSelectionMousePress
> onNewSelectionDragEnd
> onSelectionDrop

They have been replaced with FXML friendly equivalent (non default) interface methods:

> onOutsideSelectionMousePress**ed**
> onInsideSelectionMousePress**ed**
> onNewSelectionDrag**Finished**
> onSelectionDropp**ed**

Which have been implemented in `GenericStyledArea`. The references to the deprecated methods in `GenericStyledAreaBehavior` have been changed to the new ones.

During this process it was found that the `onNewSelectionDragEnd/Finished` functionality hadn't been implemented in `GenericStyledAreaBehavior`  and this was rectified as well.