### PR TITLE
Use correct replace method when SEG is String

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -547,7 +547,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      * ********************************************************************** */
 
     private final TextOps<SEG, S> segmentOps;
-    @Override public final SegmentOps<SEG, S> getSegOps() { return segmentOps; }
+    @Override public final TextOps<SEG, S> getSegOps() { return segmentOps; }
 
     private final EventStream<Boolean> autoCaretBlinksSteam;
     final EventStream<Boolean> autoCaretBlink() { return autoCaretBlinksSteam; }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
@@ -6,6 +6,7 @@ import javafx.scene.text.TextFlow;
 
 import org.fxmisc.richtext.model.Codec;
 import org.fxmisc.richtext.model.EditableStyledDocument;
+import org.fxmisc.richtext.model.ReadOnlyStyledDocument;
 import org.fxmisc.richtext.model.SimpleEditableStyledDocument;
 
 import static org.fxmisc.richtext.model.Codec.styledTextCodec;
@@ -44,7 +45,7 @@ public class InlineCssTextArea extends StyledTextArea<String, String> {
     public InlineCssTextArea(@NamedArg("text") String text) {
         this();
 
-        replace(0, 0, text, "");
+        replace(0, 0, ReadOnlyStyledDocument.fromString(text, getInitialParagraphStyle(), getInitialTextStyle(), getSegOps()));
         getUndoManager().forgetHistory();
         getUndoManager().mark();
 


### PR DESCRIPTION
Resolves #676.

In addition to fixing that issue, I also bumped the type of the area's segmentOps field from `SegmentOps` to `TextOps`. The area's constructor already requires the latter type, so this just makes it easier to call `StyledDocument`-related methods.

It is unlikely for this bug to be reproduced in the other areas because their SEG generic isn't purely text. Still, I wonder whether the method names should be changed to prevent problems like this from arising in the future. I think one test that could be written for this would be to check the number of visible paragraphs after constructing each kind of area.