### PR TITLE
Skip failing Mac test; correct Javadoc for some mouse hooks

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/mouse/ClickAndDragTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/mouse/ClickAndDragTests.java
@@ -135,6 +135,9 @@ public class ClickAndDragTests {
 
             @Test
             public void pressing_mouse_over_text_and_dragging_and_releasing_mouse_triggers_new_selection_finished() {
+                // Doesn't work on Mac builds; works on Linux & Windows
+                skip_if_on_mac();
+
                 SimpleIntegerProperty i = new SimpleIntegerProperty(0);
                 area.setOnNewSelectionDragFinished(e -> i.set(1));
                 moveTo(firstLineOfArea())

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ViewActions.java
@@ -108,9 +108,9 @@ public interface ViewActions<PS, SEG, S> {
     EventHandler<MouseEvent> getOnInsideSelectionMousePressReleased();
 
     /**
-     * Runs the consumer when the mouse is dragged in this scenario: the user has selected some text,
-     * pressed the mouse on top of the selection, dragged it to a new location within the area,
-     * but has not yet released the mouse.
+     * Runs the consumer when the mouse is dragged in this scenario: the user has pressed the mouse over some
+     * unselected text, and dragged the mouse to a new location within the area, but has not yet released the mouse.
+     * Each time the user drags the mouse without releasing it, this hook's consumer gets called.
      *
      * <p>By default, this will create a new selection or
      * {@link NavigationActions.SelectionPolicy#ADJUST} the current one to be bigger or
@@ -127,9 +127,8 @@ public interface ViewActions<PS, SEG, S> {
     ObjectProperty<Consumer<Point2D>> onNewSelectionDragProperty();
 
     /**
-     * Runs the EventHandler when the mouse is released in this scenario: the user has selected some text,
-     * pressed the mouse on top of the selection, dragged it to a new location within the area,
-     * and released the mouse.
+     * Runs the EventHandler when the mouse is released in this scenario: the user has pressed the mouse over some
+     * unselected text, and dragged the mouse to a new location within the area, and released the mouse.
      *
      * <p>By default, this will {@link NavigationActions.SelectionPolicy#ADJUST} the
      * current selection to be bigger or smaller via the code:
@@ -147,7 +146,8 @@ public interface ViewActions<PS, SEG, S> {
     /**
      * Runs the consumer when the mouse is dragged in this scenario: the user has selected some text,
      * pressed the mouse on top of the selection, dragged it to a new location within the area,
-     * but has not yet released the mouse.
+     * but has not yet released the mouse. Each time the user drags the mouse without releasing it,
+     * this hook's consumer gets called.
      *
      * <p>By default, this will {@link GenericStyledArea#displaceCaret(int) displace the caret} to that position
      * within the area via the code:


### PR DESCRIPTION
Addresses some of the issues raised in #656.

Resolves #679 and #680.