### PR TITLE
Updated Paragraph to apply styles to empty paragraphs.

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/Paragraph.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/Paragraph.java
@@ -318,8 +318,11 @@ public final class Paragraph<PS, SEG, S> {
 
     public Paragraph<PS, SEG, S> restyle(int from, StyleSpans<? extends S> styleSpans) {
         int len = styleSpans.length();
-        if(styleSpans.equals(getStyleSpans(from, from + len)) || length() == 0) {
-            return this;
+        if(styleSpans.equals(getStyleSpans(from, from + len))) {
+        	return this;
+        }
+        if(length() == 0) {
+        	return new Paragraph<>(paragraphStyle, segmentOps, segments, (StyleSpans<S>) styleSpans);
         }
 
         StyleSpans<S> left = styles.subView(0, from);

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
@@ -20,19 +20,21 @@ public class ParagraphTest {
         assertEquals(Boolean.TRUE, p.getStyleAtPosition(0));
     }
 
-    // Relates to #345 and #505: calling `EditableStyledDocument::setStyleSpans` when the style spans
-    //  would style an empty paragraph would throw an exception
+    // Relates to #345 and #505: calling `EditableStyledDocument::setStyleSpans`
+    // when styling an empty paragraph would throw an exception.
+    // Also relates to #449: where empty paragraphs were being skipped.
     @Test
     public void restylingEmptyParagraphViaStyleSpansWorks() {
         TextOps<String, Boolean> segOps = SegmentOps.styledTextOps();
         Paragraph<Void, String, Boolean> p = new Paragraph<>(null, segOps, segOps.createEmptySeg(), false);
+        assertEquals( 0, p.length() );
 
         StyleSpansBuilder<Boolean> builder = new StyleSpansBuilder<>();
         builder.add(true, 2);
         StyleSpans<Boolean> spans = builder.create();
         Paragraph<Void, String, Boolean> restyledP = p.restyle(0, spans);
 
-        assertEquals(p, restyledP);
+        assertTrue(restyledP.getStyleSpans().styleStream().allMatch( b -> b ));
     }
 
 }


### PR DESCRIPTION
This is a fix for an issue discovered in #449 where styles were not being applied to empty paragraphs. In that issue it was causing an IndexOutOfBoundsException within JavaFX.