### PR TITLE
Added GenericStyledArea.setParagraphBoxStyle

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1114,6 +1114,10 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         content.setParagraphStyle(paragraph, paragraphStyle);
     }
 
+    public void setParagraphBoxStyle(int paragraph, String paragraphStyle) {
+        virtualFlow.getCell(paragraph).getNode().setStyle(paragraphStyle);
+    }
+
     @Override
     public final S getTextStyleForInsertionAt(int pos) {
         if(useInitialStyleForInsertion.get()) {


### PR DESCRIPTION
Partially solves: #691

Now you can write this: 
``` 
codeArea.setParagraphBoxStyle(1, "-fx-padding: 20 0 0 0;")
```
And then you get something like this:
![image](https://user-images.githubusercontent.com/29373148/36562856-2c021abe-1810-11e8-95fe-33abb2ebfc48.png)

Problems:
- I believe this is not how it supposed to be solved, if you let me know how to make it better I am happy to fix it.
- If the line is edited the styling goes away. If you let me know how to fix it I will try.
