### PR TITLE
Allow multiple portions of an area's document to be updated in one call

### DIFF
--- a/richtextfx/build.gradle
+++ b/richtextfx/build.gradle
@@ -26,7 +26,7 @@ if (gradle.gradleVersion.substring(0, 1) >= "4") {
 }
 dependencies {
     compile group: 'org.reactfx', name: 'reactfx', version: '2.0-M5'
-    compile group: 'org.fxmisc.undo', name: 'undofx', version: '1.4.0'
+    compile group: 'org.fxmisc.undo', name: 'undofx', version: '2.0.0'
     compile group: 'org.fxmisc.flowless', name: 'flowless', version: '0.6'
     compile group: 'org.fxmisc.wellbehaved', name: 'wellbehavedfx', version: '0.3.1'
 

--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/MultiChangeTest.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/MultiChangeTest.java
@@ -1,0 +1,106 @@
+package org.fxmisc.richtext.api;
+
+import javafx.stage.Stage;
+import org.fxmisc.richtext.InlineCssTextAreaAppTest;
+import org.fxmisc.richtext.MultiChangeBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class MultiChangeTest extends InlineCssTextAreaAppTest {
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        super.start(stage);
+
+        // initialize area with some text
+        area.replaceText("(text)");
+    }
+
+    @Test
+    public void committing_single_change_works() {
+        interact(() -> {
+            String text = area.getText();
+            area.createMultiChange(1)
+                    .deleteText(0, 1)
+                    .commit();
+
+            assertEquals(text.substring(1), area.getText());
+        });
+    }
+
+    @Test
+    public void committing_relative_change_works() {
+        interact(() -> {
+            String text = area.getText();
+            String hello = "hello";
+            String world = "world";
+            area.createMultiChange(2)
+                    .insertText(0, hello)
+                    .insertText(0, world)
+                    .commit();
+
+            assertEquals(hello + world + text, area.getText());
+        });
+    }
+
+    @Test
+    public void committing_absolute_change_works() {
+        interact(() -> {
+            String text = area.getText();
+            String hello = "hello";
+            String world = "world";
+            area.createMultiChange(2)
+                    .insertText(0, hello)
+                    .insertTextAbsolutely(0, world)
+                    .commit();
+
+            assertEquals(world + hello + text, area.getText());
+        });
+    }
+
+    @Test
+    public void changing_same_content_multiple_times_works() {
+        interact(() -> {
+            String text = area.getText();
+
+            area.createMultiChange(4)
+                    .replaceTextAbsolutely(0, 1, "a")
+                    .replaceTextAbsolutely(0, 1, "b")
+                    .replaceTextAbsolutely(0, 1, "c")
+                    .replaceTextAbsolutely(0, 1, "d")
+                    .commit();
+
+            assertEquals("d" + text.substring(1), area.getText());
+        });
+    }
+
+    @Test
+    public void attempting_to_reuse_builder_throws_exception() {
+        interact(() -> {
+            MultiChangeBuilder<String, String, String> builder = area.createMultiChange(1)
+                    .insertText(0, "hey");
+            builder.commit();
+            try {
+                builder.commit();
+                fail();
+            } catch (IllegalStateException e) {
+                // cannot reuse builder once commit changes
+            }
+        });
+    }
+
+    @Test
+    public void attempting_to_commit_without_any_stored_changes_throws_exception() {
+        interact(() -> {
+            MultiChangeBuilder<String, String, String> builder = area.createMultiChange(1);
+            try {
+                builder.commit();
+                fail();
+            } catch (IllegalStateException e) {
+                // no changes were stored in the builder
+            }
+        });
+    }
+}

--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/UndoManagerTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/UndoManagerTests.java
@@ -1,6 +1,7 @@
 package org.fxmisc.richtext.api;
 
 import com.nitorcreations.junit.runners.NestedRunner;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.stage.Stage;
@@ -8,12 +9,13 @@ import org.fxmisc.richtext.InlineCssTextAreaAppTest;
 import org.fxmisc.richtext.RichTextFXTestBase;
 import org.fxmisc.richtext.StyledTextArea;
 import org.fxmisc.richtext.model.SimpleEditableStyledDocument;
+import org.fxmisc.richtext.model.TextChange;
 import org.fxmisc.richtext.util.UndoUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.testfx.framework.junit.ApplicationTest;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(NestedRunner.class)
 public class UndoManagerTests {
@@ -51,6 +53,96 @@ public class UndoManagerTests {
 
                 area.undo();
                 assertEquals("abc\ndef", area.getText());
+            });
+        }
+
+        @Test
+        public void multiChange_undo_and_redo_works() {
+            interact(() -> {
+                String text = "text";
+                String wrappedText = "(" + text + ")";
+                area.replaceText(wrappedText);
+                area.getUndoManager().forgetHistory();
+
+                // Text:     |(|t|e|x|t|)|
+                // Position: 0 1 2 3 4 5 6
+                area.createMultiChange(2)
+                        // delete parenthesis
+                        .deleteText(0, 1)
+                        .deleteText(5, 6)
+                        .commit();
+
+                area.undo();
+                assertEquals(wrappedText, area.getText());
+
+                area.redo();
+                assertEquals(text, area.getText());
+            });
+        }
+
+        @Test
+        public void multiChange_merge_works() {
+            interact(() -> {
+                String initialText = "123456";
+                area.replaceText(initialText);
+                area.getUndoManager().forgetHistory();
+
+                int firstCount = 0;
+                int secondCount = 3;
+
+                // Text:     |1|2|3|4|5|6|
+                // Position: 0 1 2 3 4 5 6
+                area.createMultiChange(2)
+                        // replace '1' with 'a'
+                        .replaceText(firstCount, ++firstCount, "a")
+                        // replace '4' with 'c'
+                        .replaceText(secondCount, ++secondCount, "c")
+                        .commit();
+
+                // Text:     |a|2|3|c|5|6|
+                // Position: 0 1 2 3 4 5 6
+                area.createMultiChange(2)
+                        // replace '2' with 'b'
+                        .replaceText(firstCount, ++firstCount, "b")
+                        // replace '5' with 'd'
+                        .replaceText(secondCount, ++secondCount, "d")
+                        .commit();
+
+                String finalText = "ab3cd6";
+
+                area.undo();
+                assertFalse(area.getUndoManager().isUndoAvailable());
+                assertEquals(initialText, area.getText());
+
+                area.redo();
+                assertFalse(area.getUndoManager().isRedoAvailable());
+                assertEquals(finalText, area.getText());
+            });
+        }
+
+        @Test
+        public void identity_change_works() {
+            interact(() -> {
+               area.replaceText("ttttt");
+
+               SimpleIntegerProperty richEmissions = new SimpleIntegerProperty(0);
+               SimpleIntegerProperty plainEmissions = new SimpleIntegerProperty(0);
+               area.multiRichChanges()
+                       .hook(list -> richEmissions.set(richEmissions.get() + 1))
+                       .filter(list -> !list.stream().allMatch(TextChange::isIdentity))
+                       .subscribe(list -> plainEmissions.set(plainEmissions.get() + 1));
+
+
+               int position = 0;
+               area.createMultiChange(4)
+                       .replaceText(position, ++position, "t")
+                       .replaceText(position, ++position, "t")
+                       .replaceText(position, ++position, "t")
+                       .replaceText(position, ++position, "t")
+                       .commit();
+
+               assertEquals(1, richEmissions.get());
+               assertEquals(0, plainEmissions.get());
             });
         }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -60,6 +60,7 @@ import org.fxmisc.richtext.model.GenericEditableStyledDocument;
 import org.fxmisc.richtext.model.Paragraph;
 import org.fxmisc.richtext.model.ReadOnlyStyledDocument;
 import org.fxmisc.richtext.model.PlainTextChange;
+import org.fxmisc.richtext.model.Replacement;
 import org.fxmisc.richtext.model.RichTextChange;
 import org.fxmisc.richtext.model.StyleSpans;
 import org.fxmisc.richtext.model.StyledDocument;
@@ -251,6 +252,9 @@ import org.reactfx.value.Var;
  *     To distinguish the actual operations one can do on this area from the boilerplate methods
  *     within this area (e.g. properties and their getters/setters, etc.), look at the interfaces
  *     this area implements. Each lists and documents methods that fall under that category.
+ * </p>
+ * <p>
+ *     To update multiple portions of the area's underlying document in one call, see {@link #createMultiChange()}.
  * </p>
  *
  * <h3>Calculating a Position Within the Area</h3>
@@ -525,6 +529,10 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      * Event streams                                                          *
      *                                                                        *
      * ********************************************************************** */
+
+    @Override public EventStream<List<RichTextChange<PS, SEG, S>>> multiRichChanges() { return content.multiRichChanges(); }
+
+    @Override public EventStream<List<PlainTextChange>> multiPlainChanges() { return content.multiPlainChanges(); }
 
     // text changes
     @Override public final EventStream<PlainTextChange> plainTextChanges() { return content.plainChanges(); }
@@ -1188,6 +1196,23 @@ public class GenericStyledArea<PS, SEG, S> extends Region
 
         int newCaretPos = start + replacement.length();
         selectRange(newCaretPos, newCaretPos);
+    }
+
+    void replaceMulti(List<Replacement<PS, SEG, S>> replacements) {
+        content.replaceMulti(replacements);
+
+        // don't update selection as this is not the main method through which the area is updated
+        // leave that up to the developer using it to determine what to do
+    }
+
+    @Override
+    public MultiChangeBuilder<PS, SEG, S> createMultiChange() {
+        return new MultiChangeBuilder<>(this);
+    }
+
+    @Override
+    public MultiChangeBuilder<PS, SEG, S> createMultiChange(int initialNumOfChanges) {
+        return new MultiChangeBuilder<>(this, initialNumOfChanges);
     }
 
     /* ********************************************************************** *

--- a/richtextfx/src/main/java/org/fxmisc/richtext/MultiChangeBuilder.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/MultiChangeBuilder.java
@@ -1,0 +1,412 @@
+package org.fxmisc.richtext;
+
+import javafx.scene.control.IndexRange;
+import org.fxmisc.richtext.model.ReadOnlyStyledDocument;
+import org.fxmisc.richtext.model.Replacement;
+import org.fxmisc.richtext.model.StyledDocument;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Constructs a list of {@link Replacement}s that are used to update an
+ * {@link org.fxmisc.richtext.model.EditableStyledDocument} in one call via {@link #commit()}. <strong>Note: this builder
+ * cannot be reused and a new one must be created for each multi-change.</strong>
+ *
+ * <h3>Relative vs Absolute Changes</h3>
+ * <p>
+ *     Let's say that a document has the text {@code |(|t|e|x|t||)|} where each {@code |} represents a position
+ *     in-between the characters of the text . If one wants to remove the opening
+ *     and closing parenthesis in two update calls, they would write:
+ * <pre><code>
+ * // Text:     |(|t|e|x|t|)|
+ * // Position: 0 1 2 3 4 5 6
+ * area.deleteText(0, 1); // delete the first parenthesis
+ *
+ * // now the second parenthesis is positioned in a different spot than before
+ * // Text:     |t|e|x|t|)|
+ * // Position: 0 1 2 3 4 5
+ * area.deleteText(4, 5); // delete the second parenthesis
+ * </code></pre>
+ * </p>
+ * <p>
+ *     {@code MultiChangeBuilder} can do the same thing in one call and works by applying earlier changes before
+ *     later ones. However, this creates a problem. Later changes' start and end positions must be updated to still
+ *     point to the correct spot in the text. Wouldn't it be easier to be able to define both changes in the original
+ *     coordinate system of the document before any changes were applied? Returning to the previous example,
+ *     wouldn't it be better if one could write:
+ *     <pre><code>
+ * // Text:     |(|t|e|x|t|)|
+ * // Position: 0 1 2 3 4 5 6
+ *
+ * // start multi change
+ * area.deleteText(0, 1); // delete the 1st parenthesis
+ * area.deleteText(5, 6); // delete the 2nd parenthesis
+ * // end multi change
+ * </code></pre>
+ * </p>
+ * <p>
+ *     Fortunately, that is already handled for you. Such changes are known as "relative" changes: their
+ *     start and end positions are updated to point to where they should point once all the earlier changes before
+ *     them have been applied. To execute the same code as before, we would write:
+ * <pre><code>
+ * area.createMultiChange()
+ *      // deletes the 1st parenthesis
+ *      .deleteText(0, 1)
+ *
+ *      // internally updates this to delete(4, 5), so that it deletes the 2nd parenthesis
+ *      .deleteText(5, 6)
+ *
+ *      // executes the call and updates the document
+ *      .commit();
+ * </code></pre>
+ * </p>
+ * <p>
+ *     However, a developer may sometimes want an "absolute" change: their start and end positions
+ *     are exactly what the developer specifies regardless of how changes before them modify the underlying document.
+ *     For example, the following code would still delete both parenthesis:
+ * <pre><code>
+ * area.createMultiChange()
+ *      .deleteText(0, 1) // deletes the 1st parenthesis
+ *      .deleteTextAbsolutely(4, 5) // deletes the 2nd parenthesis
+ *      .commit();
+ * </code></pre>
+ * </p>
+ * <p>
+ *     Thus, absolute changes (e.g. {@link #replaceAbsolutely(int, int, StyledDocument)}) are all the methods
+ *     which have "absolute" as a suffix and relative changes (e.g. {@link #replace(int, int, StyledDocument)})
+ *     do not. To make things easier for the developer, the methods declared here are similar to those declared
+ *     in {@link EditActions}, minus a few (e.g. {@link EditActions#append(StyledDocument)}).
+ * </p>
+ * <h3>Other Considerations</h3>
+ * <ul>
+ *     <li>
+ *         <strong>Warning: </strong> relative changes will not be updated if one starts a multi-change and fails
+ *         to commit those changes before updating the area's underlying document in a
+ *         {@link GenericStyledArea#replace(int, int, StyledDocument)} call.
+ *     </li>
+ *     <li>
+ *         The builder does not optimize performance in cases where the developer adds a later change that makes
+ *         an earlier change obsolete. For example,
+ * <pre><code>
+ * // This code...
+ * area.createMultiChange(4)
+ *     .replaceText(0, 1, "a")
+ *     .replaceTextAbsolutely(0, 1, "b")
+ *     .replaceTextAbsolutely(0, 1, "c")
+ *     .replaceTextAbsolutely(0, 1, "d")
+ *     .commit();
+ *
+ * // ...could be optimized to...
+ * area.createMultiChange(2)
+ *     .replaceText(0, 1, "a")
+ *     // .replaceTextAbsolutely(0, 1, "b") // superseded by next change
+ *     // .replaceTextAbsolutely(0, 1, "c") // superseded by next change
+ *     .replaceTextAbsolutely(0, 1, "d")
+ *     .commit();
+ * // ...as it would reduce the number of updates by two and not create all the other objects
+ * // associated with an update (e.g. RichTextChange, PlainTextChange, etc.).
+ * </code></pre>
+ *     </li>
+ * </ul>
+ */
+public class MultiChangeBuilder<PS, SEG, S> {
+
+    private final GenericStyledArea<PS, SEG, S> area;
+    private final List<Replacement<PS, SEG, S>> list;
+
+    private boolean alreadyCreated = false;
+
+    MultiChangeBuilder(GenericStyledArea<PS, SEG, S> area) {
+        this(area, new ArrayList<>());
+    }
+
+    MultiChangeBuilder(GenericStyledArea<PS, SEG, S> area, int initialListSize) {
+        this(area, new ArrayList<>(initialListSize));
+    }
+
+    private MultiChangeBuilder(GenericStyledArea<PS, SEG, S> area, List<Replacement<PS, SEG, S>> list) {
+        this.area = area;
+        this.list = list;
+    }
+
+    /**
+     * Inserts the given text at the given position.
+     *
+     * @param position The position to insert the text.
+     * @param text The text to insert.
+     */
+    public MultiChangeBuilder<PS, SEG, S> insertText(int position, String text) {
+        return replaceText(position, position, text);
+    }
+
+    /**
+     * Inserts the given text at the given position.
+     *
+     * @param position The position to insert the text.
+     * @param text The text to insert.
+     */
+    public MultiChangeBuilder<PS, SEG, S> insertTextAbsolutely(int position, String text) {
+        return replaceTextAbsolutely(position, position, text);
+    }
+
+    /**
+     * Inserts the given text at the position returned from
+     * {@code getAbsolutePosition(paragraphIndex, columnPosition)}.
+     *
+     * <p><b>Caution:</b> see {@link StyledDocument#getAbsolutePosition(int, int)} to know how the column index argument
+     * can affect the returned position.</p>
+     *
+     * @param text The text to insert
+     */
+    public MultiChangeBuilder<PS, SEG, S> insertText(int paragraphIndex, int columnPosition, String text) {
+        int index = area.getAbsolutePosition(paragraphIndex, columnPosition);
+        return replaceText(index, index, text);
+    }
+
+    /**
+     * Inserts the given text at the position returned from
+     * {@code getAbsolutePosition(paragraphIndex, columnPosition)}.
+     *
+     * <p><b>Caution:</b> see {@link StyledDocument#getAbsolutePosition(int, int)} to know how the column index argument
+     * can affect the returned position.</p>
+     *
+     * @param text The text to insert
+     */
+    public MultiChangeBuilder<PS, SEG, S> insertTextAbsolutely(int paragraphIndex, int columnPosition, String text) {
+        int index = area.getAbsolutePosition(paragraphIndex, columnPosition);
+        return replaceTextAbsolutely(index, index, text);
+    }
+
+    /**
+     * Inserts the given rich-text content at the given position.
+     *
+     * @param position The position to insert the text.
+     * @param document The rich-text content to insert.
+     */
+    public MultiChangeBuilder<PS, SEG, S> insert(int position, StyledDocument<PS, SEG, S> document) {
+        return replace(position, position, document);
+    }
+
+    /**
+     * Inserts the given rich-text content at the given position.
+     *
+     * @param position The position to insert the text.
+     * @param document The rich-text content to insert.
+     */
+    public MultiChangeBuilder<PS, SEG, S> insertAbsolutely(int position, StyledDocument<PS, SEG, S> document) {
+        return replaceAbsolutely(position, position, document);
+    }
+
+    /**
+     * Inserts the given rich-text content at the position returned from
+     * {@code getAbsolutePosition(paragraphIndex, columnPosition)}.
+     *
+     * <p><b>Caution:</b> see {@link StyledDocument#getAbsolutePosition(int, int)} to know how the column index argument
+     * can affect the returned position.</p>
+     *
+     * @param document The rich-text content to insert.
+     */
+    public MultiChangeBuilder<PS, SEG, S> insert(int paragraphIndex, int columnPosition, StyledDocument<PS, SEG, S> document) {
+        int pos = area.getAbsolutePosition(paragraphIndex, columnPosition);
+        return replace(pos, pos, document);
+    }
+
+    /**
+     * Inserts the given rich-text content at the position returned from
+     * {@code getAbsolutePosition(paragraphIndex, columnPosition)}.
+     *
+     * <p><b>Caution:</b> see {@link StyledDocument#getAbsolutePosition(int, int)} to know how the column index argument
+     * can affect the returned position.</p>
+     *
+     * @param document The rich-text content to insert.
+     */
+    public MultiChangeBuilder<PS, SEG, S> insertAbsolutely(int paragraphIndex, int columnPosition, StyledDocument<PS, SEG, S> document) {
+        int pos = area.getAbsolutePosition(paragraphIndex, columnPosition);
+        return replaceAbsolutely(pos, pos, document);
+    }
+
+    /**
+     * Removes a range of text.
+     *
+     * @param range The range of text to delete. It must not be null. Its start and end values specify the start
+     *              and end positions within the area.
+     *
+     * @see #deleteText(int, int)
+     */
+    public MultiChangeBuilder<PS, SEG, S> deleteText(IndexRange range) {
+        return deleteText(range.getStart(), range.getEnd());
+    }
+
+    /**
+     * Removes a range of text.
+     *
+     * @param range The range of text to delete. It must not be null. Its start and end values specify the start
+     *              and end positions within the area.
+     *
+     * @see #deleteText(int, int)
+     */
+    public MultiChangeBuilder<PS, SEG, S> deleteTextAbsolutely(IndexRange range) {
+        return deleteTextAbsolutely(range.getStart(), range.getEnd());
+    }
+
+    /**
+     * Removes a range of text.
+     *
+     * It must hold {@code 0 <= start <= end <= getLength()}.
+     *
+     * @param start Start position of the range to remove
+     * @param end End position of the range to remove
+     */
+    public MultiChangeBuilder<PS, SEG, S> deleteText(int start, int end) {
+        return replaceText(start, end, "");
+    }
+
+    /**
+     * Removes a range of text.
+     *
+     * It must hold {@code 0 <= start <= end <= getLength()}.
+     *
+     * @param start Start position of the range to remove
+     * @param end End position of the range to remove
+     */
+    public MultiChangeBuilder<PS, SEG, S> deleteTextAbsolutely(int start, int end) {
+        return replaceTextAbsolutely(start, end, "");
+    }
+
+    /**
+     * Removes a range of text.
+     *
+     * It must hold {@code 0 <= start <= end <= getLength()} where
+     * {@code start = getAbsolutePosition(startParagraph, startColumn);} and is <b>inclusive</b>, and
+     * {@code int end = getAbsolutePosition(endParagraph, endColumn);} and is <b>exclusive</b>.
+     *
+     * <p><b>Caution:</b> see {@link StyledDocument#getAbsolutePosition(int, int)} to know how the column index argument
+     * can affect the returned position.</p>
+     */
+    public MultiChangeBuilder<PS, SEG, S> deleteText(int startParagraph, int startColumn, int endParagraph, int endColumn) {
+        int start = area.getAbsolutePosition(startParagraph, startColumn);
+        int end = area.getAbsolutePosition(endParagraph, endColumn);
+        return replaceText(start, end, "");
+    }
+
+    /**
+     * Removes a range of text.
+     *
+     * It must hold {@code 0 <= start <= end <= getLength()} where
+     * {@code start = getAbsolutePosition(startParagraph, startColumn);} and is <b>inclusive</b>, and
+     * {@code int end = getAbsolutePosition(endParagraph, endColumn);} and is <b>exclusive</b>.
+     *
+     * <p><b>Caution:</b> see {@link StyledDocument#getAbsolutePosition(int, int)} to know how the column index argument
+     * can affect the returned position.</p>
+     */
+    public MultiChangeBuilder<PS, SEG, S> deleteTextAbsolutely(int startParagraph, int startColumn, int endParagraph, int endColumn) {
+        int start = area.getAbsolutePosition(startParagraph, startColumn);
+        int end = area.getAbsolutePosition(endParagraph, endColumn);
+        return replaceTextAbsolutely(start, end, "");
+    }
+
+    /**
+     * Replaces a range of characters with the given text.
+     *
+     * It must hold {@code 0 <= start <= end <= getLength()}.
+     *
+     * @param start Start index of the range to replace, inclusive.
+     * @param end End index of the range to replace, exclusive.
+     * @param text The text to put in place of the deleted range.
+     * It must not be null.
+     */
+    public MultiChangeBuilder<PS, SEG, S> replaceText(int start, int end, String text) {
+        return relativeReplace(start, end, ReadOnlyStyledDocument.fromString(
+                text, area.getInitialParagraphStyle(), area.getInitialTextStyle(), area.getSegOps())
+        );
+    }
+
+    /**
+     * Replaces a range of characters with the given text.
+     *
+     * It must hold {@code 0 <= start <= end <= getLength()}.
+     *
+     * @param start Start index of the range to replace, inclusive.
+     * @param end End index of the range to replace, exclusive.
+     * @param text The text to put in place of the deleted range.
+     * It must not be null.
+     */
+    public MultiChangeBuilder<PS, SEG, S> replaceTextAbsolutely(int start, int end, String text) {
+        return absoluteReplace(start, end, ReadOnlyStyledDocument.fromString(
+                text, area.getInitialParagraphStyle(), area.getInitialTextStyle(), area.getSegOps())
+        );
+    }
+
+    /**
+     * Replaces a range of characters with the given rich-text document.
+     */
+    public MultiChangeBuilder<PS, SEG, S> replace(int start, int end, StyledDocument<PS, SEG, S> replacement) {
+        return relativeReplace(start, end, ReadOnlyStyledDocument.from(replacement));
+    }
+
+    /**
+     * Replaces a range of characters with the given rich-text document.
+     */
+    public MultiChangeBuilder<PS, SEG, S> replaceAbsolutely(int start, int end, StyledDocument<PS, SEG, S> replacement) {
+        return absoluteReplace(start, end, ReadOnlyStyledDocument.from(replacement));
+    }
+
+    /**
+     * Applies all the changes stored in this object to the underlying document of the area. <strong>Note: this builder
+     * cannot be reused and a new one must be created for each multi-change.</strong>
+     */
+    public final void commit() {
+        ensureNotYetCreated();
+        ensureHasChanges();
+        alreadyCreated = true;
+        area.replaceMulti(Collections.unmodifiableList(list));
+    }
+
+    private MultiChangeBuilder<PS, SEG, S> relativeReplace(int start, int end, ReadOnlyStyledDocument<PS, SEG, S> replacement) {
+        if (list.isEmpty()) {
+            return absoluteReplace(start, end, replacement);
+        } else {
+
+            int realStart = start;
+            int realEnd = end;
+            for (Replacement<PS, SEG, S> r : list) {
+                if (r.getStart() < realStart) {
+                    realStart += r.getNetLength();
+                    if (r.getEnd() < realEnd) {
+                        realEnd += r.getNetLength();
+                    }
+                } else if (r.getEnd() < realEnd) {
+                    realEnd += r.getNetLength();
+                }
+            }
+            return absoluteReplace(realStart, realEnd, replacement);
+        }
+    }
+
+    private MultiChangeBuilder<PS, SEG, S> absoluteReplace(int start, int end, ReadOnlyStyledDocument<PS, SEG, S> replacement) {
+        // TODO: could be optimized to ignore earlier changes when later one makes them obsolete
+        // for example:
+        //  builder
+        //  .replaceTextAbsolutely(0, 1, "a")
+        //  .replaceTextAbsolutely(0, 1, "b")
+        //  .replaceTextAbsolutely(0, 1, "c") // makes previous two commits obsolete
+        //  .commit();
+        list.add(new Replacement<>(start, end, replacement));
+
+        return this;
+    }
+
+    private void ensureNotYetCreated() {
+        if (alreadyCreated) {
+            throw new IllegalStateException("Cannot reuse a builder multiple times");
+        }
+    }
+
+    private void ensureHasChanges() {
+        if (list.isEmpty()) {
+            throw new IllegalStateException("Cannot commit multiple changes since none have been added");
+        }
+    }
+}

--- a/richtextfx/src/main/java/org/fxmisc/richtext/MultiChangeBuilder.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/MultiChangeBuilder.java
@@ -19,6 +19,7 @@ import java.util.List;
  *     Let's say that a document has the text {@code |(|t|e|x|t||)|} where each {@code |} represents a position
  *     in-between the characters of the text . If one wants to remove the opening
  *     and closing parenthesis in two update calls, they would write:
+ * </p>
  * <pre><code>
  * // Text:     |(|t|e|x|t|)|
  * // Position: 0 1 2 3 4 5 6
@@ -29,14 +30,14 @@ import java.util.List;
  * // Position: 0 1 2 3 4 5
  * area.deleteText(4, 5); // delete the second parenthesis
  * </code></pre>
- * </p>
  * <p>
  *     {@code MultiChangeBuilder} can do the same thing in one call and works by applying earlier changes before
  *     later ones. However, this creates a problem. Later changes' start and end positions must be updated to still
  *     point to the correct spot in the text. Wouldn't it be easier to be able to define both changes in the original
  *     coordinate system of the document before any changes were applied? Returning to the previous example,
  *     wouldn't it be better if one could write:
- *     <pre><code>
+ * </p>
+ * <pre><code>
  * // Text:     |(|t|e|x|t|)|
  * // Position: 0 1 2 3 4 5 6
  *
@@ -45,11 +46,11 @@ import java.util.List;
  * area.deleteText(5, 6); // delete the 2nd parenthesis
  * // end multi change
  * </code></pre>
- * </p>
  * <p>
  *     Fortunately, that is already handled for you. Such changes are known as "relative" changes: their
  *     start and end positions are updated to point to where they should point once all the earlier changes before
  *     them have been applied. To execute the same code as before, we would write:
+ * </p>
  * <pre><code>
  * area.createMultiChange()
  *      // deletes the 1st parenthesis
@@ -61,18 +62,17 @@ import java.util.List;
  *      // executes the call and updates the document
  *      .commit();
  * </code></pre>
- * </p>
  * <p>
  *     However, a developer may sometimes want an "absolute" change: their start and end positions
  *     are exactly what the developer specifies regardless of how changes before them modify the underlying document.
  *     For example, the following code would still delete both parenthesis:
+ * </p>
  * <pre><code>
  * area.createMultiChange()
  *      .deleteText(0, 1) // deletes the 1st parenthesis
  *      .deleteTextAbsolutely(4, 5) // deletes the 2nd parenthesis
  *      .commit();
  * </code></pre>
- * </p>
  * <p>
  *     Thus, absolute changes (e.g. {@link #replaceAbsolutely(int, int, StyledDocument)}) are all the methods
  *     which have "absolute" as a suffix and relative changes (e.g. {@link #replace(int, int, StyledDocument)})

--- a/richtextfx/src/main/java/org/fxmisc/richtext/MultiChangeBuilder.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/MultiChangeBuilder.java
@@ -372,12 +372,12 @@ public class MultiChangeBuilder<PS, SEG, S> {
             int realStart = start;
             int realEnd = end;
             for (Replacement<PS, SEG, S> r : list) {
-                if (r.getStart() < realStart) {
+                if (r.getStart() <= realStart) {
                     realStart += r.getNetLength();
-                    if (r.getEnd() < realEnd) {
+                    if (r.getEnd() <= realEnd) {
                         realEnd += r.getNetLength();
                     }
-                } else if (r.getEnd() < realEnd) {
+                } else if (r.getEnd() <= realEnd) {
                     realEnd += r.getNetLength();
                 }
             }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextEditingArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextEditingArea.java
@@ -8,6 +8,7 @@ import javafx.scene.control.IndexRange;
 import org.fxmisc.richtext.model.EditableStyledDocument;
 import org.fxmisc.richtext.model.Paragraph;
 import org.fxmisc.richtext.model.PlainTextChange;
+import org.fxmisc.richtext.model.Replacement;
 import org.fxmisc.richtext.model.RichTextChange;
 import org.fxmisc.richtext.model.SegmentOps;
 import org.fxmisc.richtext.model.StyledDocument;
@@ -15,6 +16,7 @@ import org.reactfx.EventStream;
 import org.reactfx.SuspendableNo;
 import org.reactfx.value.Var;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -155,9 +157,19 @@ public interface TextEditingArea<PS, SEG, S> {
      *********************/
 
     /**
+     * See {@link org.fxmisc.richtext.model.EditableStyledDocument#multiPlainChanges()}
+     */
+    EventStream<List<PlainTextChange>> multiPlainChanges();
+
+    /**
      * See {@link org.fxmisc.richtext.model.EditableStyledDocument#plainChanges()}
      */
     EventStream<PlainTextChange> plainTextChanges();
+
+    /**
+     * See {@link org.fxmisc.richtext.model.EditableStyledDocument#multiRichChanges()}
+     */
+    EventStream<List<RichTextChange<PS, SEG, S>>> multiRichChanges();
 
     /**
      * See {@link org.fxmisc.richtext.model.EditableStyledDocument#richChanges()}
@@ -309,6 +321,18 @@ public interface TextEditingArea<PS, SEG, S> {
      * Replaces a range of characters with the given rich-text document.
      */
     void replace(int start, int end, StyledDocument<PS, SEG, S> replacement);
+
+    /**
+     * Starts building a list of changes to be used to update multiple portions of the underlying document
+     * in one call. To execute the changes, call {@link MultiChangeBuilder#commit()}. If the number of
+     * changes are known at compile time, use {@link #createMultiChange(int)} for better memory efficiency.
+     */
+    MultiChangeBuilder<PS, SEG, S> createMultiChange();
+
+    /**
+     * Same as {@link #createMultiChange()} but the number of changes are specified to be more memory efficient.
+     */
+    MultiChangeBuilder<PS, SEG, S> createMultiChange(int numOfChanges);
 
     /**
      * Replaces a range of characters with the given segment.

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocumentBase.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocumentBase.java
@@ -12,6 +12,7 @@ import org.reactfx.Subscription;
 import org.reactfx.Suspendable;
 import org.reactfx.SuspendableEventStream;
 import org.reactfx.SuspendableNo;
+import org.reactfx.collection.ListChangeAccumulator;
 import org.reactfx.collection.LiveList;
 import org.reactfx.collection.LiveListBase;
 import org.reactfx.collection.MaterializedListModification;
@@ -39,34 +40,38 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
 
         @Override
         protected Subscription observeInputs() {
-            return parChanges.subscribe(mod -> {
-                mod = mod.trim();
-                QuasiListModification<Paragraph<PS, SEG, S>> qmod =
-                        QuasiListModification.create(mod.getFrom(), mod.getRemoved(), mod.getAddedSize());
-                notifyObservers(qmod.asListChange());
+            return parChangesList.subscribe(list -> {
+                ListChangeAccumulator<Paragraph<PS, SEG, S>> accumulator = new ListChangeAccumulator<>();
+                for (MaterializedListModification<Paragraph<PS, SEG, S>> mod : list) {
+                    mod = mod.trim();
+
+                    // add the quasiListModification itself, not as a quasiListChange, in case some overlap
+                    accumulator.add(QuasiListModification.create(mod.getFrom(), mod.getRemoved(), mod.getAddedSize()));
+                }
+                notifyObservers(accumulator.asListChange());
             });
         }
     }
 
     private ReadOnlyStyledDocument<PS, SEG, S> doc;
 
-    private final EventSource<RichTextChange<PS, SEG, S>> internalRichChanges = new EventSource<>();
-    private final SuspendableEventStream<RichTextChange<PS, SEG, S>> richChanges = internalRichChanges.pausable();
-    @Override public EventStream<RichTextChange<PS, SEG, S>> richChanges() { return richChanges; }
+    private final EventSource<List<RichTextChange<PS, SEG, S>>> internalRichChangeList = new EventSource<>();
+    private final SuspendableEventStream<List<RichTextChange<PS, SEG, S>>> richChangeList = internalRichChangeList.pausable();
+    @Override public EventStream<List<RichTextChange<PS, SEG, S>>> multiRichChanges() { return richChangeList; }
 
-    private final Val<String> internalText = Val.create(() -> doc.getText(), internalRichChanges);
+    private final Val<String> internalText = Val.create(() -> doc.getText(), internalRichChangeList);
     private final SuspendableVal<String> text = internalText.suspendable();
     @Override public String getText() { return text.getValue(); }
     @Override public Val<String> textProperty() { return text; }
 
 
-    private final Val<Integer> internalLength = Val.create(() -> doc.length(), internalRichChanges);
+    private final Val<Integer> internalLength = Val.create(() -> doc.length(), internalRichChangeList);
     private final SuspendableVal<Integer> length = internalLength.suspendable();
     @Override public int getLength() { return length.getValue(); }
     @Override public Val<Integer> lengthProperty() { return length; }
     @Override public int length() { return length.getValue(); }
 
-    private final EventSource<MaterializedListModification<Paragraph<PS, SEG, S>>> parChanges =
+    private final EventSource<List<MaterializedListModification<Paragraph<PS, SEG, S>>>> parChangesList =
             new EventSource<>();
 
     private final SuspendableList<Paragraph<PS, SEG, S>> paragraphs = new ParagraphList().suspendable();
@@ -95,7 +100,7 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
                 length,
 
                 // add streams after properties, to be released before them
-                richChanges,
+                richChangeList,
 
                 // paragraphs to be released first
                 paragraphs);
@@ -128,24 +133,28 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
     }
 
     @Override
+    public void replaceMulti(List<Replacement<PS, SEG, S>> replacements) {
+        doc.replaceMulti(replacements).exec(this::updateMulti);
+    }
+
+    @Override
     public void replace(int start, int end, StyledDocument<PS, SEG, S> replacement) {
-        doc.replace(start, end, ReadOnlyStyledDocument.from(replacement)).exec(this::update);
+        doc.replace(start, end, ReadOnlyStyledDocument.from(replacement)).exec(this::updateSingle);
     }
 
     @Override
     public void setStyle(int from, int to, S style) {
-        doc.replace(from, to, removed -> removed.mapParagraphs(par -> par.restyle(style))).exec(this::update);
+        doc.replace(from, to, removed -> removed.mapParagraphs(par -> par.restyle(style))).exec(this::updateSingle);
     }
 
     @Override
     public void setStyle(int paragraphIndex, S style) {
-        doc.replaceParagraph(paragraphIndex, p -> p.restyle(style)).exec(this::update);
+        doc.replaceParagraph(paragraphIndex, p -> p.restyle(style)).exec(this::updateSingle);
     }
 
     @Override
     public void setStyle(int paragraphIndex, int fromCol, int toCol, S style) {
-        doc.replace(paragraphIndex, fromCol, toCol, d -> d.mapParagraphs(p -> p.restyle(style)))
-                .exec(this::update);
+        doc.replace(paragraphIndex, fromCol, toCol, d -> d.mapParagraphs(p -> p.restyle(style))).exec(this::updateSingle);
     }
 
     @Override
@@ -161,7 +170,7 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
                 i = j.offsetBy(1, Forward); // skip the newline
             }
             return new ReadOnlyStyledDocument<>(pars);
-        }).exec(this::update);
+        }).exec(this::updateSingle);
     }
 
     @Override
@@ -171,7 +180,7 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
 
     @Override
     public void setParagraphStyle(int paragraphIndex, PS style) {
-        doc.replaceParagraph(paragraphIndex, p -> p.setParagraphStyle(style)).exec(this::update);
+        doc.replaceParagraph(paragraphIndex, p -> p.setParagraphStyle(style)).exec(this::updateSingle);
     }
 
     @Override
@@ -191,14 +200,21 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
      *                                                                        *
      * ********************************************************************** */
 
-    private void update(
+    private void updateSingle(
             ReadOnlyStyledDocument<PS, SEG, S> newValue,
             RichTextChange<PS, SEG, S> change,
             MaterializedListModification<Paragraph<PS, SEG, S>> parChange) {
+        updateMulti(newValue, Collections.singletonList(change), Collections.singletonList(parChange));
+    }
+
+    private void updateMulti(
+            ReadOnlyStyledDocument<PS, SEG, S> newValue,
+            List<RichTextChange<PS, SEG, S>> richChanges,
+            List<MaterializedListModification<Paragraph<PS, SEG, S>>> parChanges) {
         this.doc = newValue;
         beingUpdated.suspendWhile(() -> {
-            internalRichChanges.push(change);
-            parChanges.push(parChange);
+            internalRichChangeList.push(richChanges);
+            parChangesList.push(parChanges);
         });
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/Replacement.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/Replacement.java
@@ -1,0 +1,53 @@
+package org.fxmisc.richtext.model;
+
+import java.util.Objects;
+
+/**
+ * Encapsulates the all the arguments for {@link EditableStyledDocument#replace(int, int, StyledDocument)}.
+ */
+public class Replacement<PS, SEG, S> {
+
+    private final int start;
+    public final int getStart() { return start; }
+
+    private final int end;
+    public final int getEnd() { return end; }
+
+    private final ReadOnlyStyledDocument<PS, SEG, S> document;
+    public final ReadOnlyStyledDocument<PS, SEG, S> getDocument() { return document; }
+
+    public Replacement(int start, int end, ReadOnlyStyledDocument<PS, SEG, S> document) {
+        this.start = start;
+        this.end = end;
+        this.document = document;
+    }
+
+    /**
+     * Shortcut for {@code document.length() - (end - start)}
+     */
+    public int getNetLength() {
+        return document.length() - (end - start);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Replacement) {
+            Replacement<?, ?, ?> that = (Replacement<?, ?, ?>) obj;
+            return Objects.equals(start, that.start) &&
+                    Objects.equals(end, that.end) &&
+                    Objects.equals(document, that.document);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end, document);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Replacement(start=%s end=%s document=%s)", start, end, document);
+    }
+}

--- a/richtextfx/src/main/java/org/fxmisc/richtext/util/UndoManagerInactivityWrapper.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/util/UndoManagerInactivityWrapper.java
@@ -58,28 +58,8 @@ final class UndoManagerInactivityWrapper<C> implements UndoManager<C> {
     }
 
     @Override
-    public Val<C> nextToUndoProperty() {
-        return delegate.nextToUndoProperty();
-    }
-
-    @Override
-    public C getNextToUndo() {
-        return delegate.getNextToUndo();
-    }
-
-    @Override
     public Val<C> nextRedoProperty() {
         return delegate.nextRedoProperty();
-    }
-
-    @Override
-    public Val<C> nextToRedoProperty() {
-        return delegate.nextToRedoProperty();
-    }
-
-    @Override
-    public C getNextToRedo() {
-        return delegate.getNextToRedo();
     }
 
     @Override


### PR DESCRIPTION
Resolves #574.

One feature still lacking in this PR: the UndoManager cannot undo/redo a list of changes because I still need to think through how two lists of changes should be merged and what their identity values would be.


