### PR TITLE
Add PsychSQL to list of projects that use RichTextFX

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Who uses RichTextFX?
 - [JuliarFuture](https://juliar.org)
 - [BlueJ](https://www.bluej.org/)
 - [JabRef](http://www.jabref.org/)
+- [PsychSQL](http://softbydoc.dx.am/?page_id=135)
 
 If you use RichTextFX in an interesting project, I would like to know!
 


### PR DESCRIPTION
Update README.md to include PsychSQL (a one-file SQL client on top of JDBC) in the "Who uses RichTextFX?" section.