### PR TITLE
Prevent `multiPlainChanges()` from emitting an empty list

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/SpellChecking.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/SpellChecking.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.BreakIterator;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -19,6 +20,7 @@ import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
+import org.reactfx.Subscription;
 
 public class SpellChecking extends Application {
 
@@ -33,11 +35,13 @@ public class SpellChecking extends Application {
         StyleClassedTextArea textArea = new StyleClassedTextArea();
         textArea.setWrapText(true);
 
-        textArea.richChanges()
-                .filter(ch -> !ch.getInserted().equals(ch.getRemoved())) // XXX
+        Subscription cleanupWhenFinished = textArea.multiPlainChanges()
+                .successionEnds(Duration.ofMillis(500))
                 .subscribe(change -> {
                     textArea.setStyleSpans(0, computeHighlighting(textArea.getText()));
                 });
+
+        // call when no longer need it: `cleanupWhenFinished.unsubscribe();`
 
         // load the dictionary
         try (InputStream input = getClass().getResourceAsStream("spellchecking.dict");

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/EditableStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/EditableStyledDocument.java
@@ -67,11 +67,14 @@ public interface EditableStyledDocument<PS, SEG, S> extends StyledDocument<PS, S
      */
     default EventStream<List<PlainTextChange>> multiPlainChanges() {
         return multiRichChanges()
+                // map to a List<PlainTextChange>
                 .map(list -> Arrays.asList(list.stream()
-                        .map(RichTextChange::toPlainTextChange)
                         // filter out rich changes where the style was changed but text wasn't added/removed
-                        .filter(pc -> !pc.isIdentity())
-                        .toArray(PlainTextChange[]::new)));
+                        .filter(rtc -> !rtc.isPlainTextIdentity())
+                        .map(RichTextChange::toPlainTextChange)
+                        .toArray(PlainTextChange[]::new)))
+                // only emit non-empty lists
+                .filter(list -> !list.isEmpty());
     }
 
     /**

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/RichTextChange.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/RichTextChange.java
@@ -37,4 +37,12 @@ public class RichTextChange<PS, SEG, S> extends TextChange<StyledDocument<PS, SE
     public final PlainTextChange toPlainTextChange() {
         return new PlainTextChange(position, removed.getText(), inserted.getText());
     }
+
+    /**
+     * Equivalent to {@code richChange.toPlainTextChange().isIdentity()} but without the additional object
+     * creation via {@link #toPlainTextChange()}.
+     */
+    public final boolean isPlainTextIdentity() {
+        return removed.getText().equals(inserted.getText());
+    }
 }


### PR DESCRIPTION
Fixes #720 

Also cleans up the demos to use the new `multiPlainChanges()` API introduced in #695 