### PR TITLE
Fix bug: wrongly calculated value used for `moveToParEnd`

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/mouse/ClickAndDragTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/mouse/ClickAndDragTests.java
@@ -93,11 +93,13 @@ public class ClickAndDragTests {
 
             private String firstWord = "Some";
             private String firstParagraph = firstWord + " text goes here";
+            private String secondWord = "More";
+            private String secondParagraph = secondWord + " text goes here";
 
             @Override
             public void start(Stage stage) throws Exception {
                 super.start(stage);
-                area.replaceText(firstParagraph);
+                area.replaceText(firstParagraph + "\n" + secondParagraph);
                 area.moveTo(0);
             }
 
@@ -123,10 +125,17 @@ public class ClickAndDragTests {
             }
 
             @Test
-            public void triple_clicking_line_in_area_selects_paragraph() {
-                tripleClickOnFirstLine();
+            public void triple_clicking_line_in_area_selects_paragraph()
+                    throws InterruptedException, ExecutionException {
 
-                assertEquals(firstParagraph, area.getSelectedText());
+                int wordStart = firstParagraph.length() + 1;
+                Bounds bounds = asyncFx(
+                        () -> area.getCharacterBoundsOnScreen(wordStart, wordStart + 1).get())
+                        .get();
+
+                moveTo(bounds).doubleClickOn(PRIMARY).clickOn(PRIMARY);
+
+                assertEquals(secondParagraph, area.getSelectedText());
             }
 
             @Test

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CaretNode.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CaretNode.java
@@ -266,7 +266,7 @@ public class CaretNode extends Path implements Caret, Comparable<CaretNode> {
 
     @Override
     public void moveToParEnd() {
-        moveTo(area.getParagraphLength(getParagraphIndex()));
+        moveTo(getPosition() - getColumnPosition() + area.getParagraphLength(getParagraphIndex()));
     }
 
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CaretSelectionBind.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CaretSelectionBind.java
@@ -322,8 +322,9 @@ public interface CaretSelectionBind<PS, SEG, S> extends Selection<PS, SEG, S>, C
     void moveToAreaEnd(NavigationActions.SelectionPolicy selectionPolicy);
 
     default void selectParagraph() {
-        moveToParStart(NavigationActions.SelectionPolicy.CLEAR);
-        moveToParEnd(NavigationActions.SelectionPolicy.ADJUST);
+        int parStartPosition = getPosition() - getColumnPosition();
+        int parEndPosition = parStartPosition + getArea().getParagraphLength(getParagraphIndex());
+        selectRange(parStartPosition, parEndPosition);
     }
 
     /**

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CaretSelectionBindImpl.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CaretSelectionBindImpl.java
@@ -409,8 +409,7 @@ final class CaretSelectionBindImpl<PS, SEG, S> implements CaretSelectionBind<PS,
 
     @Override
     public void moveToParEnd(NavigationActions.SelectionPolicy selectionPolicy) {
-        int newPos = getArea().getParagraphLength(getParagraphIndex());
-        moveTo(newPos, selectionPolicy);
+        moveTo(getPosition() - getColumnPosition() + getArea().getParagraphLength(getParagraphIndex()), selectionPolicy);
     }
 
     @Override


### PR DESCRIPTION
Fixes #742.