### PR TITLE
API for visible paragraphs works when contents have blank lines

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/VisibleParagraphTest.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/VisibleParagraphTest.java
@@ -1,0 +1,48 @@
+package org.fxmisc.richtext.api;
+
+import org.fxmisc.richtext.InlineCssTextAreaAppTest;
+import org.fxmisc.richtext.model.Paragraph;
+import org.junit.Test;
+import org.junit.Assert;
+import org.reactfx.collection.LiveList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class VisibleParagraphTest extends InlineCssTextAreaAppTest {
+
+    @Test
+    public void visible_paragraph_index_mapping() {
+        String[] lines = {
+                "abc",
+                "def",
+                "ghi"
+        };
+        interact(() -> {
+            area.setWrapText(true);
+            stage.setWidth(120);
+            area.replaceText(String.join("\n", lines));
+        });
+        assertEquals(0, area.firstVisibleParToAllParIndex());
+        assertEquals(2, area.lastVisibleParToAllParIndex());
+        assertEquals(1, area.visibleParToAllParIndex(1));
+    }
+
+    @Test
+    public void visible_paragraph_index_mapping_with_blank_lines() {
+        String[] lines = {
+                "",
+                "",
+                ""
+        };
+        interact(() -> {
+            area.setWrapText(true);
+            stage.setWidth(120);
+            area.replaceText(String.join("\n", lines));
+        });
+        assertEquals(0, area.firstVisibleParToAllParIndex());
+        assertEquals(2, area.lastVisibleParToAllParIndex());
+        assertEquals(1, area.visibleParToAllParIndex(1));
+    }
+
+}

--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/VisibleParagraphTest.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/VisibleParagraphTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertFalse;
 public class VisibleParagraphTest extends InlineCssTextAreaAppTest {
 
     @Test
-    public void visible_paragraph_index_mapping() {
+    public void get_first_visible_paragraph_index_with_non_blank_lines() {
         String[] lines = {
                 "abc",
                 "def",
@@ -27,9 +27,36 @@ public class VisibleParagraphTest extends InlineCssTextAreaAppTest {
         assertEquals(2, area.lastVisibleParToAllParIndex());
         assertEquals(1, area.visibleParToAllParIndex(1));
     }
-
     @Test
-    public void visible_paragraph_index_mapping_with_blank_lines() {
+    public void get_last_visible_paragraph_index_with_non_blank_lines() {
+        String[] lines = {
+                "abc",
+                "def",
+                "ghi"
+        };
+        interact(() -> {
+            area.setWrapText(true);
+            stage.setWidth(120);
+            area.replaceText(String.join("\n", lines));
+        });
+        assertEquals(2, area.lastVisibleParToAllParIndex());
+    }
+    @Test
+    public void get_specific_visible_paragraph_index_with_non_blank_lines() {
+        String[] lines = {
+                "abc",
+                "def",
+                "ghi"
+        };
+        interact(() -> {
+            area.setWrapText(true);
+            stage.setWidth(120);
+            area.replaceText(String.join("\n", lines));
+        });
+        assertEquals(2, area.visibleParToAllParIndex(2));
+    }
+    @Test
+    public void get_first_visible_paragraph_index_with_all_blank_lines() {
         String[] lines = {
                 "",
                 "",
@@ -41,8 +68,85 @@ public class VisibleParagraphTest extends InlineCssTextAreaAppTest {
             area.replaceText(String.join("\n", lines));
         });
         assertEquals(0, area.firstVisibleParToAllParIndex());
+    }
+    @Test
+    public void get_last_visible_paragraph_index_with_all_blank_lines() {
+        String[] lines = {
+                "",
+                "",
+                ""
+        };
+        interact(() -> {
+            area.setWrapText(true);
+            stage.setWidth(120);
+            area.replaceText(String.join("\n", lines));
+        });
         assertEquals(2, area.lastVisibleParToAllParIndex());
-        assertEquals(1, area.visibleParToAllParIndex(1));
+    }
+    @Test
+    public void get_specific_visible_paragraph_index_with_all_blank_lines() {
+        String[] lines = {
+                "",
+                "",
+                ""
+        };
+        interact(() -> {
+            area.setWrapText(true);
+            stage.setWidth(120);
+            area.replaceText(String.join("\n", lines));
+        });
+        assertEquals(2, area.visibleParToAllParIndex(2));
     }
 
+    @Test
+    public void get_first_visible_paragraph_index_with_some_blank_lines() {
+        String[] lines = {
+                "abc",
+                "",
+                "",
+                "",
+                "def",
+                ""
+        };
+        interact(() -> {
+            area.setWrapText(true);
+            stage.setWidth(120);
+            area.replaceText(String.join("\n", lines));
+        });
+        assertEquals(0, area.firstVisibleParToAllParIndex());
+    }
+    @Test
+    public void get_last_visible_paragraph_index_with_some_blank_lines() {
+        String[] lines = {
+                "abc",
+                "",
+                "",
+                "",
+                "def",
+                ""
+        };
+        interact(() -> {
+            area.setWrapText(true);
+            stage.setWidth(120);
+            area.replaceText(String.join("\n", lines));
+        });
+        assertEquals(5, area.lastVisibleParToAllParIndex());
+    }
+    @Test
+    public void get_specific_visible_paragraph_index_with_some_blank_lines() {
+        String[] lines = {
+                "abc",
+                "",
+                "",
+                "",
+                "def",
+                ""
+        };
+        interact(() -> {
+            area.setWrapText(true);
+            stage.setWidth(120);
+            area.replaceText(String.join("\n", lines));
+        });
+        assertEquals(3, area.visibleParToAllParIndex(3));
+    }
 }


### PR DESCRIPTION
These test cases are for issue #777.

It shows that `firstVisibleParToAllParIndex`, `lastVisibleParToAllParIndex` and `visibleParToAllParIndex` will throw out "Unreachable code" errors when the contents have blank lines/paragraphs.

However, it not always behaves like that.
- When the paragraphs list start and end with non-blank lines,  `visibleParToAllParIndex` will works correctly even there are some blank lines.
- When the edit area has scroll bar, its behavior has much more complicated pattern. For example, when visible region only contains blank lines, it will throw out errors. After scroll to some non-blank lines, it will work again.

What I know now is that `getVisibleParagraphs` returns wrong list corresponding to blank lines, so that all those 3 functions above won't work because it's impossible to find a same item in list returned from  `getParagraphs`.