### PR TITLE
ParagraphText: immediately remove listeners from selections and carets on disposal

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1463,6 +1463,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                 box.wrapTextProperty().unbind();
                 box.graphicFactoryProperty().unbind();
                 box.graphicOffset.unbind();
+                box.dispose();
 
                 firstParPseudoClass.unsubscribe();
                 lastParPseudoClass.unsubscribe();

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -22,7 +22,6 @@ import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
-import javafx.scene.control.IndexRange;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Paint;
 import javafx.scene.text.TextFlow;
@@ -116,6 +115,10 @@ class ParagraphBox<PS, SEG, S> extends Region {
             }
         });
         graphicOffset.addListener(obs -> requestLayout());
+    }
+
+    void dispose() {
+        text.dispose();
     }
 
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -98,6 +98,14 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
 
         selectionRangeListener = (obs, ov, nv) -> requestLayout();
         selections.addListener((MapChangeListener.Change<? extends Selection<PS, SEG, S>, ? extends SelectionPath> change) -> {
+            if (change.wasRemoved()) {
+                SelectionPath p = change.getValueRemoved();
+                p.rangeProperty().removeListener(selectionRangeListener);
+                p.layoutXProperty().unbind();
+                p.layoutYProperty().unbind();
+
+                getChildren().remove(p);
+            }
             if (change.wasAdded()) {
                 SelectionPath p = change.getValueAdded();
                 p.rangeProperty().addListener(selectionRangeListener);
@@ -106,18 +114,19 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
 
                 getChildren().add(selectionShapeStartIndex, p);
                 updateSingleSelection(p);
-            } else if (change.wasRemoved()) {
-                SelectionPath p = change.getValueRemoved();
-                p.rangeProperty().removeListener(selectionRangeListener);
-                p.layoutXProperty().unbind();
-                p.layoutYProperty().unbind();
-
-                getChildren().remove(p);
             }
         });
 
         caretPositionListener = (obs, ov, nv) -> requestLayout();
         carets.addListener((SetChangeListener.Change<? extends CaretNode> change) -> {
+            if (change.wasRemoved()) {
+                CaretNode caret = change.getElementRemoved();
+                caret.columnPositionProperty().removeListener(caretPositionListener);
+                caret.layoutXProperty().unbind();
+                caret.layoutYProperty().unbind();
+
+                getChildren().remove(caret);
+            }
             if (change.wasAdded()) {
                 CaretNode caret = change.getElementAdded();
                 caret.columnPositionProperty().addListener(caretPositionListener);
@@ -126,13 +135,6 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
 
                 getChildren().add(caret);
                 updateSingleCaret(caret);
-            } else if (change.wasRemoved()) {
-                CaretNode caret = change.getElementRemoved();
-                caret.columnPositionProperty().removeListener(caretPositionListener);
-                caret.layoutXProperty().unbind();
-                caret.layoutYProperty().unbind();
-
-                getChildren().remove(caret);
             }
         });
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -220,17 +220,9 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
     }
 
     void dispose() {
-        for (SelectionPath p : selections.values()) {
-            p.rangeProperty().removeListener(selectionRangeListener);
-            p.layoutXProperty().unbind();
-            p.layoutYProperty().unbind();
-        }
-
-        for (CaretNode caret : carets) {
-            caret.columnPositionProperty().removeListener(caretPositionListener);
-            caret.layoutXProperty().unbind();
-            caret.layoutYProperty().unbind();
-        }
+        // this removes listeners (in selections and carets listeners) and avoids memory leaks
+        selections.clear();
+        carets.clear();
     }
 
     public Paragraph<PS, SEG, S> getParagraph() {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -1,6 +1,5 @@
 package org.fxmisc.richtext;
 
-import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -19,7 +18,6 @@ import java.util.function.UnaryOperator;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableMap;
@@ -98,11 +96,45 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
         Val<Double> leftInset = Val.map(insetsProperty(), Insets::getLeft);
         Val<Double> topInset = Val.map(insetsProperty(), Insets::getTop);
 
-        selectionRangeListener = new SelectionRangeChangeListener<>(this);
-        selections.addListener(new SelectionsSetListener<>(leftInset, selectionRangeListener, topInset, this));
+        selectionRangeListener = (obs, ov, nv) -> requestLayout();
+        selections.addListener((MapChangeListener.Change<? extends Selection<PS, SEG, S>, ? extends SelectionPath> change) -> {
+            if (change.wasAdded()) {
+                SelectionPath p = change.getValueAdded();
+                p.rangeProperty().addListener(selectionRangeListener);
+                p.layoutXProperty().bind(leftInset);
+                p.layoutYProperty().bind(topInset);
 
-        caretPositionListener = new CaretPositionChangeListener<>(this);
-        carets.addListener(new CaretsChangeListener<>(leftInset, caretPositionListener, topInset, this));
+                getChildren().add(selectionShapeStartIndex, p);
+                updateSingleSelection(p);
+            } else if (change.wasRemoved()) {
+                SelectionPath p = change.getValueRemoved();
+                p.rangeProperty().removeListener(selectionRangeListener);
+                p.layoutXProperty().unbind();
+                p.layoutYProperty().unbind();
+
+                getChildren().remove(p);
+            }
+        });
+
+        caretPositionListener = (obs, ov, nv) -> requestLayout();
+        carets.addListener((SetChangeListener.Change<? extends CaretNode> change) -> {
+            if (change.wasAdded()) {
+                CaretNode caret = change.getElementAdded();
+                caret.columnPositionProperty().addListener(caretPositionListener);
+                caret.layoutXProperty().bind(leftInset);
+                caret.layoutYProperty().bind(topInset);
+
+                getChildren().add(caret);
+                updateSingleCaret(caret);
+            } else if (change.wasRemoved()) {
+                CaretNode caret = change.getElementRemoved();
+                caret.columnPositionProperty().removeListener(caretPositionListener);
+                caret.layoutXProperty().unbind();
+                caret.layoutYProperty().unbind();
+
+                getChildren().remove(caret);
+            }
+        });
 
         // XXX: see the note at highlightTextFill
 //        highlightTextFill.addListener(new ChangeListener<Paint>() {
@@ -417,133 +449,6 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
         updateAllCaretShapes();
         updateAllSelectionShapes();
         updateBackgroundShapes();
-    }
-
-    private static final class SelectionsSetListener<PS, SEG, S> implements
-                MapChangeListener<Selection<PS, SEG, S>, SelectionPath> {
-        private final Val<Double> leftInset;
-        private final ChangeListener<IndexRange> requestLayout1;
-        private final Val<Double> topInset;
-        private final WeakReference<ParagraphText<PS, SEG, S>> ref;
-
-        public SelectionsSetListener(
-                    Val<Double> leftInset,
-                    ChangeListener<IndexRange> requestLayout1,
-                    Val<Double> topInset,
-                    ParagraphText<PS, SEG, S> paragraphText) {
-            this.leftInset = leftInset;
-            this.requestLayout1 = requestLayout1;
-            this.topInset = topInset;
-            ref = new WeakReference<>(paragraphText);
-        }
-
-        @Override
-        public void onChanged(
-                    javafx.collections.MapChangeListener.Change<? extends Selection<PS, SEG, S>, ? extends SelectionPath> change) {
-            ParagraphText<PS, SEG, S> paragraphText = ref.get();
-            if (null == paragraphText) {
-                change.getMap().removeListener(this);
-                return;
-            }
-
-            if (change.wasAdded()) {
-                SelectionPath p = change.getValueAdded();
-                p.rangeProperty().addListener(requestLayout1);
-
-                p.layoutXProperty().bind(leftInset);
-                p.layoutYProperty().bind(topInset);
-
-                paragraphText.getChildren().add(paragraphText.selectionShapeStartIndex, p);
-                paragraphText.updateSingleSelection(p);
-            } else if (change.wasRemoved()) {
-                SelectionPath p = change.getValueRemoved();
-                p.rangeProperty().removeListener(requestLayout1);
-
-                p.layoutXProperty().unbind();
-                p.layoutYProperty().unbind();
-
-                paragraphText.getChildren().remove(p);
-            }
-        }
-    }
-
-    private static final class SelectionRangeChangeListener<PS, SEG, S> implements ChangeListener<IndexRange> {
-        private final WeakReference<ParagraphText<PS, SEG, S>> ref;
-
-        public SelectionRangeChangeListener(ParagraphText<PS, SEG, S> paragraphText) {
-            ref = new WeakReference<>(paragraphText);
-        }
-
-        @Override
-        public void changed(ObservableValue<? extends IndexRange> observable, IndexRange oldValue, IndexRange newValue) {
-            ParagraphText<PS, SEG, S> paragraphText = ref.get();
-            if (null == paragraphText) {
-                observable.removeListener(this);
-            } else {
-                paragraphText.requestLayout();
-            }
-        }
-    }
-
-    private static final class CaretPositionChangeListener<PS, SEG, S> implements ChangeListener<Integer> {
-        private final WeakReference<ParagraphText<PS, SEG, S>> ref;
-
-        public CaretPositionChangeListener(ParagraphText<PS, SEG, S> paragraphText) {
-            ref = new WeakReference<>(paragraphText);
-        }
-
-        @Override
-        public void changed(ObservableValue<? extends Integer> observable, Integer oldValue, Integer newValue) {
-            ParagraphText<PS, SEG, S> paragraphText = ref.get();
-            if (null == paragraphText) {
-                observable.removeListener(this);
-            } else {
-                paragraphText.requestLayout();
-            }
-        }
-    }
-
-    private static final class CaretsChangeListener<PS, SEG, S> implements SetChangeListener<CaretNode> {
-        private final Val<Double> leftInset;
-        private final ChangeListener<Integer> requestLayout2;
-        private final Val<Double> topInset;
-        private final WeakReference<ParagraphText<PS, SEG, S>> ref;
-
-        private CaretsChangeListener(
-                    Val<Double> leftInset,
-                    ChangeListener<Integer> requestLayout2,
-                    Val<Double> topInset,
-                    ParagraphText<PS, SEG, S> paragraphText) {
-            ref = new WeakReference<>(paragraphText);
-            this.leftInset = leftInset;
-            this.requestLayout2 = requestLayout2;
-            this.topInset = topInset;
-        }
-
-        @Override
-        public void onChanged(Change<? extends CaretNode> change) {
-            ParagraphText<PS, SEG, S> paragraphText = ref.get();
-            if (null == paragraphText) {
-                change.getSet().removeListener(this);
-                return;
-            }
-            if (change.wasAdded()) {
-                CaretNode caret = change.getElementAdded();
-                caret.columnPositionProperty().addListener(requestLayout2);
-                caret.layoutXProperty().bind(leftInset);
-                caret.layoutYProperty().bind(topInset);
-
-                paragraphText.getChildren().add(caret);
-                paragraphText.updateSingleCaret(caret);
-            } else if (change.wasRemoved()) {
-                CaretNode caret = change.getElementRemoved();
-                caret.columnPositionProperty().removeListener(requestLayout2);
-                caret.layoutXProperty().unbind();
-                caret.layoutYProperty().unbind();
-
-                paragraphText.getChildren().remove(caret);
-            }
-        }
     }
 
     private static class CustomCssShapeHelper<T> {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -459,10 +459,11 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
 
         @Override
         public void changed(ObservableValue<? extends IndexRange> observable, IndexRange oldValue, IndexRange newValue) {
-            if (null == ref.get()) {
+            ParagraphText<PS, SEG, S> paragraphText = ref.get();
+            if (null == paragraphText) {
                 observable.removeListener(this);
             } else {
-                ref.get().requestLayout();
+                paragraphText.requestLayout();
             }
         }
     }
@@ -476,10 +477,11 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
 
         @Override
         public void changed(ObservableValue<? extends Integer> observable, Integer oldValue, Integer newValue) {
-            if (null == ref.get()) {
+            ParagraphText<PS, SEG, S> paragraphText = ref.get();
+            if (null == paragraphText) {
                 observable.removeListener(this);
             } else {
-                ref.get().requestLayout();
+                paragraphText.requestLayout();
             }
         }
     }


### PR DESCRIPTION
This PR immediately removes listeners (in class `ParagraphText`) from `SelectionPath` and `Caret` on disposal instead of waiting for GC (this improves PR #779, issue #627). Without this change, disposed ParagraphText objects may still listen to selection and caret and do some useless stuff.

Since the weak listeners added in PR #779 are no longer necessary, I've removed the listener classes again and moved selection and caret listeners code back to constructor (saves 100 lines of code).