### PR TITLE
avoid scrolling current line to top of view when start editing

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1479,6 +1479,12 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     /** Assumes this method is called within a {@link #suspendVisibleParsWhile(Runnable)} block */
     private void followCaret() {
         int parIdx = getCurrentParagraph();
+
+        // Make sure that cells are up-to-date to avoid scrolling current line to top when
+        // start editing, which may occur under certain circumstances. E.g. if having embedded
+        // images, which results in some lines that are much higher then the average line height.
+        virtualFlow.layout();
+
         Cell<Paragraph<PS, SEG, S>, ParagraphBox<PS, SEG, S>> cell = virtualFlow.getCell(parIdx);
         Bounds caretBounds = cell.getNode().getCaretBounds(caretSelectionBind.getUnderlyingCaret());
         double graphicWidth = cell.getNode().getGraphicPrefWidth();


### PR DESCRIPTION
This PR fixes a painful behavior that I noticed in [Markdown Writer FX](https://github.com/JFormDesigner/markdown-writer-fx):
When I start typing into the current line, RichTextFX immediately
scrolls the current line to the top of the view.

Turns out that this happens only if embedded images feature is enabled
and if there are of course some embedded images before the current line.

The cause for the behaviour is in `GenericStyledArea.followCaret()`.
For some unknown reason, the cell of the current line that is returned by
`virtualFlow.getCell(parIdx)` is not visible (`cell.getNode().isVisible() == false`)
although it is visible on screen.

Later on in `Navigator.visit(MinDistanceTo targetPosition)`, the VirtualFlow still
thinks that is is not visible and invokes `Navigator.placeStartAtMayCrop()` to
scroll the current line to the top of the view.

The fix is easy: `virtualFlow.layout()`

Then we have a visible cell in `followCaret()` and also later in
`Navigator.visit(MinDistanceTo targetPosition)`, which then invokes
`placeToViewport()` and scrolls only when really necessary.


This PR probably fixes also issue #724, which describes the same strange behavior:
> ... press a key which inserts a char, moves the Caret or anything else, moves the line/paragraph you just edited to the top of the area viewport.