### PR TITLE
Fix height paragraph box height calculation

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -228,7 +228,7 @@ class ParagraphBox<PS, SEG, S> extends Region {
     @Override
     protected double computePrefHeight(double width) {
         Insets insets = getInsets();
-        double overhead = getGraphicPrefWidth() - insets.getLeft() - insets.getRight();
+        double overhead = getGraphicPrefWidth() + insets.getLeft() + insets.getRight();
         return text.prefHeight(width - overhead) + insets.getTop() + insets.getBottom();
     }
 


### PR DESCRIPTION
The insets were removed from the "overhead" when they should have been
added. This was asking the text for its preferred height if it had
(width + insets) space, rather than (width - insets).

Because of this, some paragraphs give a preferred height of one line
less than they should (because they wouldn't need to wrap given the
extra space that's actually occupied by the insets).

Fixes #809

