### PR TITLE
Fix Paragraph returning incorrectly styled subsequence

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/Paragraph.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/Paragraph.java
@@ -272,7 +272,7 @@ public final class Paragraph<PS, SEG, S> {
         } else if (start == length()) {
             // in case one is using EitherOps<SegmentOps, SegmentOps>, force the empty segment
             // to use the left ops' default empty seg, not the right one's empty seg
-            return new Paragraph<>(paragraphStyle, segmentOps, segmentOps.createEmptySeg(), styles.subView(0, 0));
+            return new Paragraph<>(paragraphStyle, segmentOps, segmentOps.createEmptySeg(), styles.subView(start,start));
         } else if(start < length()) {
             Position pos = navigator.offsetToPosition(start, Forward);
             int segIdx = pos.getMajor();

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
@@ -62,4 +62,19 @@ public class ParagraphTest {
         Paragraph<Void, String, Collection<String>> restyledP = p.restyle(0, spans);
         assertEquals( test, restyledP.getStyleSpans().getStyleSpan( 0 ).getStyle() );
     }
+	
+    // Relates to #815 where an undo after deleting a portion of styled text in a multi-
+    // styled paragraph causes an exception in UndoManager receiving an unexpected change.
+    @Test
+    public void multiStyleParagraphReturnsCorrect_subSequenceOfLength() {
+
+    	Collection<String> test = Collections.singleton("test");
+        TextOps<String, Collection<String>> segOps = SegmentOps.styledTextOps();
+        StyleSpansBuilder ssb = new StyleSpansBuilder<>(2);
+        ssb.add( Collections.EMPTY_LIST, 8 );
+        ssb.add( test, 8 );
+        
+        Paragraph<Void, String, Collection<String>> p = new Paragraph<>(null, segOps, "noStyle hasStyle", ssb.create());
+        assertEquals( test, p.subSequence( p.length() ).getStyleOfChar(0) );
+    }
 }


### PR DESCRIPTION
With reference to issue #815 Paragraph returns an incorrectly styled sub-sequence when the paragraph contains multiple styles and a sub-sequence is requested from the end of the paragraph which is inside a style.