### PR TITLE
Fixed caret position off by one on wrapped multiline

### DIFF
--- a/richtextfx/src/main/java9/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java9/org/fxmisc/richtext/TextFlowExt.java
@@ -109,10 +109,10 @@ class TextFlowExt extends TextFlow {
         int charIdx = hit.getCharIndex();
         boolean leading = hit.isLeading();
 
-        if ( ! leading ) {
+        if ( ! leading && getLineCount() > 1) {
             // If this is a wrapped paragraph and hit character is at end of hit line, make sure that the
             // "character hit" stays at the end of the hit line (and not at the beginning of the next line).
-            leading = (getLineCount() > 1 && charIdx + 1 >= span.getStart() + span.getLength());
+            leading = (getLineOfCharacter(charIdx) + 1 < getLineCount() && charIdx + 1 >= span.getStart() + span.getLength());
         }
 
         if(x < lineBounds.getMinX() || x > lineBounds.getMaxX()) {


### PR DESCRIPTION
Fixes #833 where the caret isn't positioned correctly at the end of the last line in a multiline paragraph.