### PR TITLE
Fix highlight fill

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -314,12 +314,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      * ********************************************************************** */
 
     /**
-     * Background fill for highlighted text.
-     */
-    private final StyleableObjectProperty<Paint> highlightFill
-            = new CustomStyleableProperty<>(Color.DODGERBLUE, "highlightFill", this, HIGHLIGHT_FILL);
-
-    /**
      * Text color for highlighted text.
      */
     private final StyleableObjectProperty<Paint> highlightTextFill
@@ -1571,10 +1565,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
      *                                                                        *
      * ********************************************************************** */
 
-    private static final CssMetaData<GenericStyledArea<?, ?, ?>, Paint> HIGHLIGHT_FILL = new CustomCssMetaData<>(
-            "-fx-highlight-fill", StyleConverter.getPaintConverter(), Color.DODGERBLUE, s -> s.highlightFill
-    );
-
     private static final CssMetaData<GenericStyledArea<?, ?, ?>, Paint> HIGHLIGHT_TEXT_FILL = new CustomCssMetaData<>(
             "-fx-highlight-text-fill", StyleConverter.getPaintConverter(), Color.WHITE, s -> s.highlightTextFill
     );
@@ -1584,7 +1574,6 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     static {
         List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<>(Region.getClassCssMetaData());
 
-        styleables.add(HIGHLIGHT_FILL);
         styleables.add(HIGHLIGHT_TEXT_FILL);
 
         CSS_META_DATA_LIST = Collections.unmodifiableList(styleables);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/SelectionPath.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/SelectionPath.java
@@ -37,6 +37,9 @@ public class SelectionPath extends Path {
     SelectionPath(Val<IndexRange> range) {
         setManaged(false);
         this.range = range;
+        highlightFill.addListener( (ob,ov,nv) -> setFill( nv ) );
+        setFill( getHighlightFill() );
+        setStrokeWidth( 0.0 );
     }
 
     @Override

--- a/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-area.css
+++ b/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-area.css
@@ -10,8 +10,3 @@
     -rtfx-blink-rate: 500ms;
     -fx-stroke-width: 1.0;
 }
-
-.styled-text-area .selection {
-    -fx-fill: dodgerblue;
-    -fx-stroke-width: 0;
-}


### PR DESCRIPTION
The highlight fill property has been broken since 0.9.0 as a result of the multiple selection capability being added.

It can now be set again via CSS with either of:

```css
.styled-text-area .selection { -fx-fill: lime; }
/* or */
.styled-text-area .selection { -fx-highlight-fill: lime; }
/* or */
.styled-text-area .main-selection { -fx-highlight-fill: pink; }
/* or */
.styled-text-area .main-selection { -fx-fill: pink; }
```