### PR TITLE
Added line highlighter enhancement

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/Selection.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/Selection.java
@@ -189,7 +189,9 @@ public interface Selection<PS, SEG, S> {
     void dispose();
 
     /**
-     * Gets the name of this selection. Each selection in an area must have a unique name.
+     * Gets the name of this selection. Each selection in an area must have a unique name.<br>
+     * The name is also used as a StyleClass, so the Selection can be styled using CSS selectors
+     * from Path, Shape, and Node eg:<br>.styled-text-area .my-selection { -fx-fill: lime; }
      */
     String getSelectionName();
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/SelectionImpl.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/SelectionImpl.java
@@ -116,6 +116,8 @@ public class SelectionImpl<PS, SEG, S> implements Selection<PS, SEG, S>, Compara
 
     /**
      * Creates a selection with both the start and end position at 0.
+     * @param name must be unique and is also used as a StyleClass for
+     * configuration via CSS using selectors from Path, Shape, and Node.
      */
     public SelectionImpl(String name, GenericStyledArea<PS, SEG, S> area) {
         this(name, area, 0, 0);
@@ -130,7 +132,8 @@ public class SelectionImpl<PS, SEG, S> implements Selection<PS, SEG, S>, Compara
     }
 
     /**
-     * Creates a selection
+     * Creates a selection. Name must be unique and is also used as a StyleClass
+     * for configuration via CSS using selectors from Path, Shape, and Node. 
      */
     public SelectionImpl(String name, GenericStyledArea<PS, SEG, S> area, int startPosition, int endPosition) {
         this(name, area, new IndexRange(startPosition, endPosition), area.beingUpdatedProperty());


### PR DESCRIPTION
This PR is for RFE  #841 adding the following API to GenericStyledArea:

```java
setLineHighlighterFill( Paint highlight )
setLineHighlighterOn( boolean show )
isLineHighlighterOn()
```

The highlighter can be styled via CSS using selectors from Path, Shape, and Node. For example:

```css
.styled-text-area .line-highlighter { -fx-fill: lime; }
/* or */
.line-highlighter { -fx-highlight-fill: lime; }
```

Any added custom Selections can now also be styled via CSS using the selection's name.