### PR TITLE
Fixed not highlighting from beginning of line after adding text when

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1194,7 +1194,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
             
             Consumer<Bounds> caretListener = b -> 
             {
-                if ( b.getMinY() != caretPrevY ) {
+                if ( b.getMinY() != caretPrevY || getCaretColumn() == 1 ) {
                 	adjustHighlighterRange.run();
                     caretPrevY = b.getMinY();
                 }


### PR DESCRIPTION
Fixed [#845](https://github.com/FXMisc/RichTextFX/pull/845#issuecomment-552252829) where when typing on an empty line the highlighter wasn't rendering from the beginning of the line.