### PR TITLE
Changed styled-text-area CSS

### DIFF
--- a/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-area.css
+++ b/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-area.css
@@ -2,8 +2,12 @@
     -fx-cursor: text;
 }
 
+.styled-text-area .paragraph-box {
+    -fx-padding: -0.5 0 -0.5 0;
+}
+
 .styled-text-area .paragraph-box .paragraph-text {
-    -fx-padding: 0 2px;
+    -fx-line-spacing: 1;
 }
 
 .styled-text-area .caret {


### PR DESCRIPTION
Fixes [#738](https://github.com/FXMisc/RichTextFX/issues/738#issuecomment-555592054) where a thin white line appears between paragraphs but only if navigating with scrollbar/mouse.