### PR TITLE
Added test and anchor properties fix

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/selection/PositionTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/selection/PositionTests.java
@@ -159,6 +159,7 @@ public class PositionTests extends InlineCssTextAreaAppTest {
         });
     }
 
+    @Test
     public void deletion_which_includes_selection_and_which_occurs_at_end_of_area_moves_selection_to_new_area_end() {
         interact(() -> {
            selection.selectRange(area.getLength(), area.getLength());
@@ -166,5 +167,17 @@ public class PositionTests extends InlineCssTextAreaAppTest {
            assertEquals(area.getLength(), selection.getStartPosition());
            assertEquals(area.getLength(), selection.getEndPosition());
         });
+    }
+    
+    @Test
+    public void anchor_updates_correctly_with_listener_attached() {
+        interact(() -> {
+        	area.clear();
+        	area.anchorProperty().addListener( (ob,ov,nv) -> nv++ );
+        	area.appendText("asdf");
+            area.selectRange(1,2);
+            assertEquals("s",area.getSelectedText());
+            assertEquals(1,area.getAnchor());
+         });
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CaretSelectionBindImpl.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CaretSelectionBindImpl.java
@@ -431,6 +431,10 @@ final class CaretSelectionBindImpl<PS, SEG, S> implements CaretSelectionBind<PS,
     public void displaceSelection(int startPosition, int endPosition) {
         doUpdate(() -> {
             delegateSelection.selectRange(startPosition, endPosition);
+
+            if ( startPosition < endPosition && internalStartedByAnchor.getValue() ) {
+            	internalStartedByAnchor.setValue( false ); // See #874
+            }
             internalStartedByAnchor.setValue(startPosition < endPosition);
         });
     }
@@ -449,6 +453,10 @@ final class CaretSelectionBindImpl<PS, SEG, S> implements CaretSelectionBind<PS,
     private void doSelect(int startPosition, int endPosition, boolean anchorIsStart) {
         doUpdate(() -> {
             delegateSelection.selectRange(startPosition, endPosition);
+
+            if ( anchorIsStart && internalStartedByAnchor.getValue() ) {
+                internalStartedByAnchor.setValue( false ); // See #874
+            }
             internalStartedByAnchor.setValue(anchorIsStart);
 
             delegateCaret.moveTo(anchorIsStart ? endPosition : startPosition);


### PR DESCRIPTION
Fixes #874 anchor properties not updating correctly if they have listeners attached.

The problem seems to come down to the `internalStartedByAnchor` Boolean property not firing on each invocation of `setValue`, but only when the actual value held changes.

The most non intrusive and safest fix, I feel, is to just toggle the Boolean property when needed in order to fire any relevant change listeners.