### PR TITLE
Added test and anchor properties fix

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/selection/PositionTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/selection/PositionTests.java
@@ -159,6 +159,7 @@ public class PositionTests extends InlineCssTextAreaAppTest {
         });
     }
 
+    @Test
     public void deletion_which_includes_selection_and_which_occurs_at_end_of_area_moves_selection_to_new_area_end() {
         interact(() -> {
            selection.selectRange(area.getLength(), area.getLength());
@@ -166,5 +167,17 @@ public class PositionTests extends InlineCssTextAreaAppTest {
            assertEquals(area.getLength(), selection.getStartPosition());
            assertEquals(area.getLength(), selection.getEndPosition());
         });
+    }
+    
+    @Test
+    public void anchor_updates_correctly_with_listener_attached() {
+        interact(() -> {
+            area.clear();
+            area.anchorProperty().addListener( (ob,ov,nv) -> nv++ );
+            area.appendText("asdf");
+            area.selectRange(1,2);
+            assertEquals("s",area.getSelectedText());
+            assertEquals(1,area.getAnchor());
+         });
     }
 }


### PR DESCRIPTION
Fixes #874 anchor properties not updating correctly if they have listeners attached.

The problem seems to come down to the internalStartedByAnchor Boolean property not firing on each invocation of setValue, but only when the actual value held changes.

Replacing Boolean with BooleanEvent which is just a **local** POJO that holds an immutable boolean produces the desired behavior.