### PR TITLE
Fixed initial collection capacity values.

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -52,11 +52,11 @@ import javafx.scene.shape.StrokeType;
  */
 class ParagraphText<PS, SEG, S> extends TextFlowExt {
 
-    private final ObservableSet<CaretNode> carets = FXCollections.observableSet(new HashSet<>(1));
+    private final ObservableSet<CaretNode> carets = FXCollections.observableSet(new HashSet<>(2));
     public final ObservableSet<CaretNode> caretsProperty() { return carets; }
 
     private final ObservableMap<Selection<PS, SEG, S>, SelectionPath> selections =
-            FXCollections.observableMap(new HashMap<>(1));
+            FXCollections.observableMap(new HashMap<>(2));
     public final ObservableMap<Selection<PS, SEG, S>, SelectionPath> selectionsProperty() { return selections; }
 
     private final MapChangeListener<? super Selection<PS, SEG, S>, ? super SelectionPath> selectionPathListener;


### PR DESCRIPTION
Fixed initial HashMap and HashSet capacity values.

With a load factor of .75 the lowest initial capacity should be 2 and not 1 otherwise the collection will resize immediately upon the first addition.

