### PR TITLE
Added convenient text field alignment capabilities

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextField.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextField.java
@@ -2,6 +2,7 @@ package org.fxmisc.richtext;
 
 import org.fxmisc.richtext.model.SimpleEditableStyledDocument;
 
+import javafx.scene.text.TextAlignment;
 import javafx.scene.text.TextFlow;
 
 /**
@@ -19,5 +20,10 @@ public class InlineCssTextField extends StyledTextField<String,String>
         this(); replaceText( text );
         getUndoManager().forgetHistory();
         getUndoManager().mark();
+    }
+
+    @Override
+    protected void changeAlignment( TextAlignment txtAlign ) {
+        setParagraphStyle( 0, "-fx-text-alignment: "+ txtAlign );
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextField.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextField.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 
 import org.fxmisc.richtext.model.SimpleEditableStyledDocument;
 
+import javafx.scene.text.TextAlignment;
+
 /**
  * A TextField that uses style classes, i.e. <code>getStyleClass().add(String)</code>, to define the styles of text segments.
  * <p>Use CSS Style Class ".styled-text-field" for styling the control.
@@ -54,5 +56,11 @@ public class StyleClassedTextField extends StyledTextField<Collection<String>, C
      */
     public void setStyleClass( int from, int to, String styleClass ) {
         setStyle( from, to, Collections.singletonList( styleClass ) );
+    }
+
+    @Override
+    protected void changeAlignment( TextAlignment txtAlign ) {
+        // Set to style class as defined in "styled-text-field-caspian.css" AND "styled-text-field-modena.css"
+        setParagraphStyle( 0, Collections.singletonList( txtAlign.toString().toLowerCase() ) );
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextField.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyledTextField.java
@@ -1,5 +1,7 @@
 package org.fxmisc.richtext;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
@@ -10,6 +12,10 @@ import javafx.application.Application;
 import javafx.beans.NamedArg;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
+import javafx.css.CssMetaData;
+import javafx.css.StyleConverter;
+import javafx.css.Styleable;
+import javafx.css.StyleableObjectProperty;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.scene.AccessibleRole;
@@ -22,6 +28,7 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
+import javafx.scene.text.TextAlignment;
 import javafx.scene.text.TextFlow;
 
 /**
@@ -29,14 +36,22 @@ import javafx.scene.text.TextFlow;
  * will be styled is not yet specified in this class, but use {@link StyleClassedTextField} for a style class
  * approach to styling the text and {@link InlineCssTextField} for an inline css approach to styling the text.
  *
+ * <p>Use CSS Style Class ".styled-text-field" for styling the control.</p>
+ * 
  * @param <PS> type of paragraph style
  * @param <S> type of style that can be applied to text.
  * 
  * @author Jurgen
  */
-public class StyledTextField<PS, S> extends StyledTextArea
+public abstract class StyledTextField<PS, S> extends StyledTextArea<PS, S>
 {
-    private final Pattern VERTICAL_WHITESPACE = Pattern.compile( "\\v+" );
+    private final static List<CssMetaData<? extends Styleable, ?>> CSS_META_DATA_LIST;
+
+    private final static CssMetaData<StyledTextField,TextAlignment> TEXT_ALIGNMENT = new CustomCssMetaData<>(
+        "-fx-alignment", (StyleConverter<?,TextAlignment>) StyleConverter.getEnumConverter(TextAlignment.class),
+        TextAlignment.LEFT, s -> (StyleableObjectProperty) s.textAlignmentProperty()
+    );
+    private final static Pattern VERTICAL_WHITESPACE = Pattern.compile( "\\v+" );
     private final static String STYLE_SHEET;
     private final static double HEIGHT;
     static {
@@ -46,6 +61,9 @@ public class StyledTextField<PS, S> extends StyledTextArea
         globalCSS = "styled-text-field-"+ globalCSS.toLowerCase() +".css";
         STYLE_SHEET = StyledTextField.class.getResource( globalCSS ).toExternalForm();
 
+        List<CssMetaData<? extends Styleable, ?>> styleables = new ArrayList<>(GenericStyledArea.getClassCssMetaData());
+        styleables.add(TEXT_ALIGNMENT);  CSS_META_DATA_LIST = Collections.unmodifiableList(styleables);
+
         // Ugly hack to get a TextFields default height :(
         // as it differs between Caspian, Modena, etc.
         TextField tf = new TextField( "GetHeight" );
@@ -54,6 +72,7 @@ public class StyledTextField<PS, S> extends StyledTextArea
     }
 
     private boolean selectAll = true;
+    private StyleableObjectProperty<TextAlignment> textAlignment;
 
 
     public StyledTextField(@NamedArg("initialParagraphStyle") PS initialParagraphStyle,
@@ -76,7 +95,7 @@ public class StyledTextField<PS, S> extends StyledTextArea
                 KE.consume();
             }
             else if ( KE.getCode() == KeyCode.TAB ) {
-            	traverse( this.getParent(), this, KE.isShiftDown() ? -1 : +1 );
+                traverse( this.getParent(), this, KE.isShiftDown() ? -1 : +1 );
                 KE.consume();
             }
         });
@@ -136,16 +155,23 @@ public class StyledTextField<PS, S> extends StyledTextArea
         return traverse( p.getParent(), p, dir ); // up
     }
 
-
-    public void setText( String text )
-    {
-        replaceText( text );
+    /**
+     * Specifies how the text should be aligned when there is empty space within the TextField.
+     * To configure via CSS use {@code -fx-alignment:} and values from {@link javafx.scene.text.TextAlignment}.
+     */
+    public final ObjectProperty<TextAlignment> textAlignmentProperty() {
+        if (textAlignment == null) {
+            textAlignment = new CustomStyleableProperty<>( TextAlignment.LEFT, "textAlignment", this, TEXT_ALIGNMENT );
+            textAlignment.addListener( (ob,ov,alignment) -> changeAlignment( alignment ) );
+        }
+        return textAlignment;
     }
+    public final TextAlignment getAlignment() { return textAlignment == null ? TextAlignment.LEFT : textAlignment.getValue(); }
+    public final void setAlignment( TextAlignment value ) { textAlignmentProperty().setValue( value ); }
+    protected abstract void changeAlignment( TextAlignment txtAlign );
 
     /**
-     * The action handler associated with this text field, or
-     * {@code null} if no action handler is assigned.
-     *
+     * The action handler associated with this text field, or {@code null} if no action handler is assigned.
      * The action handler is normally called when the user types the ENTER key.
      */
     private ObjectProperty<EventHandler<ActionEvent>> onAction = new ObjectPropertyBase<EventHandler<ActionEvent>>() {
@@ -174,8 +200,21 @@ public class StyledTextField<PS, S> extends StyledTextArea
         super.replaceText( start, end, VERTICAL_WHITESPACE.matcher( text ).replaceAll( " " ) );
     }
 
+    public void setText( String text )
+    {
+        replaceText( text );
+    }
+
     /** This is a <b>no op</b> for text fields and therefore marked as <i>deprecated</i>. */
     @Override @Deprecated public void setWrapText( boolean value ) {}
     /** This <u>always</u> returns <b>false</b> for styled text fields. */
     @Override public boolean isWrapText() { return false; }
+
+
+    @Override public List<CssMetaData<? extends Styleable, ?>> getCssMetaData() {
+        return CSS_META_DATA_LIST;
+    }
+    public static List<CssMetaData<? extends Styleable, ?>> getClassCssMetaData() {
+        return CSS_META_DATA_LIST;
+    }
 }

--- a/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-field-caspian.css
+++ b/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-field-caspian.css
@@ -1,7 +1,7 @@
 .styled-text-field
 {
     -fx-cursor: text;
-	-fx-text-fill: -fx-text-inner-color;
+    -fx-text-fill: -fx-text-inner-color;
     -fx-background-color: -fx-shadow-highlight-color, -fx-text-box-border, -fx-control-inner-background;
     -fx-background-insets: 0, 1, 2;
     -fx-background-radius: 3, 2, 2;
@@ -15,9 +15,24 @@
 }
 .styled-text-field:disabled
 {
-	-fx-opacity: -fx-disabled-opacity;
+    -fx-opacity: -fx-disabled-opacity;
 }
-.styled-text-field .main-selection
+.main-selection
 {
-	-fx-fill: #0093ff;
+    -fx-fill: #0093ff;
+}
+
+// Text alignment classes for StyleClassedTextField
+
+.center
+{
+    -fx-text-alignment: center;
+}
+.left
+{
+    -fx-text-alignment: left;
+}
+.right
+{
+    -fx-text-alignment: right;
 }

--- a/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-field-modena.css
+++ b/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-field-modena.css
@@ -17,9 +17,24 @@
 }
 .styled-text-field:disabled
 {
-	-fx-opacity: 0.4;
+    -fx-opacity: 0.4;
 }
-.styled-text-field .main-selection
+.main-selection
 {
-	-fx-fill: #0096C9;
+    -fx-fill: #0096C9;
+}
+
+// Text alignment classes for StyleClassedTextField
+
+.center
+{
+    -fx-text-alignment: center;
+}
+.left
+{
+    -fx-text-alignment: left;
+}
+.right
+{
+    -fx-text-alignment: right;
 }


### PR DESCRIPTION
JavaFX's `TextField` has a property and associated methods to determine the alignment of text in the field.
This PR adds similar methods to _StyledTextField_ as a convenience and to aid switching from `TextField`.
The only difference is that `TextField` used `Pos` as its value while _StyledTextField_ uses `TextAlignment`.

Note that `TextAlignment.JUSTIFY` isn't currently accommodated.
`-fx-alignment`  can be used for CSS styling.