### PR TITLE
Fixed RichTextChange reported by ReadOnlyStyledDocument replace

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/UndoManagerTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/UndoManagerTests.java
@@ -162,6 +162,17 @@ public class UndoManagerTests {
                assertEquals(0, plainEmissions.get());
             });
         }
+        
+        @Test
+        public void testForBug904() {
+        	String firstLine = "some text\n";
+        	write( firstLine );
+        	interact( () -> area.setStyle( 5, 9, "-fx-font-weight: bold;" ) );
+        	write( "new line" );
+        	area.getUndoManager().preventMerge();
+            area.append( area.getContent().subSequence( firstLine.length()-1, area.getLength() ) );
+            interact( area::undo ); // should not throw Unexpected change received exception 
+        }
 
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/ReadOnlyStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/ReadOnlyStyledDocument.java
@@ -419,7 +419,8 @@ public final class ReadOnlyStyledDocument<PS, SEG, S> implements StyledDocument<
             return start.map(l0::split).map((l, removed) -> {
                 ReadOnlyStyledDocument<PS, SEG, S> replacement = f.apply(removed);
                 ReadOnlyStyledDocument<PS, SEG, S> doc = l.concatR(replacement).concat(r);
-                RichTextChange<PS, SEG, S> change = new RichTextChange<>(pos, removed, replacement);
+                // Next we use doc.subSequence instead of replacement because Paragraph.concat's returned paragraph style can vary.
+                RichTextChange<PS, SEG, S> change = new RichTextChange<>(pos, removed, doc.subSequence(pos, pos+replacement.length()));
                 List<Paragraph<PS, SEG, S>> addedPars = doc.getParagraphs().subList(start.major, start.major + replacement.getParagraphCount());
                 MaterializedListModification<Paragraph<PS, SEG, S>> parChange =
                         MaterializedListModification.create(start.major, removedPars, addedPars);


### PR DESCRIPTION
Fixes #904 

The problem turned out to be that when ReadOnlyStyledDocument does a replace then it is assumed that the provided replacement is the actual change that has occurred in the document. This is not always the case though due to paragraph concatenation having various rules determining if the left or right hand side style is going to be used if either of the paragraphs is empty.