### PR TITLE
Provide suspendable undo manager

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/UndoManagerTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/UndoManagerTests.java
@@ -9,10 +9,12 @@ import org.fxmisc.richtext.InlineCssTextAreaAppTest;
 import org.fxmisc.richtext.RichTextFXTestBase;
 import org.fxmisc.richtext.StyledTextArea;
 import org.fxmisc.richtext.model.SimpleEditableStyledDocument;
+import org.fxmisc.richtext.model.RichTextChange;
 import org.fxmisc.richtext.model.TextChange;
 import org.fxmisc.richtext.util.UndoUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.reactfx.SuspendableYes;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -172,6 +174,20 @@ public class UndoManagerTests {
         	area.getUndoManager().preventMerge();
             area.append( area.getContent().subSequence( firstLine.length()-1, area.getLength() ) );
             interact( area::undo ); // should not throw Unexpected change received exception 
+        }
+
+        @Test
+        public void suspendable_UndoManager_skips_style_check() {
+        	
+            SuspendableYes suspendUndo = new SuspendableYes();
+            area.setUndoManager( UndoUtils.richTextSuspendableUndoManager( area, suspendUndo ) );
+            write( "some text\n" );
+            interact( () -> suspendUndo.suspendWhile( () -> area.setStyle( 5, 9, "-fx-font-weight: bold;" ) ) );
+            write( "new line" );
+            interact( area::undo ); // should not throw Unexpected change received exception
+            
+            area.setUndoManager( UndoUtils.defaultUndoManager( area ) );
+            RichTextChange.skipStyleComparison( false );
         }
 
     }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/RichTextChange.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/RichTextChange.java
@@ -45,4 +45,31 @@ public class RichTextChange<PS, SEG, S> extends TextChange<StyledDocument<PS, SE
     public final boolean isPlainTextIdentity() {
         return removed.getText().equals(inserted.getText());
     }
+    
+    private static boolean skipStyleComparison = false;
+    
+    public static void skipStyleComparison( boolean value )
+    {
+        skipStyleComparison = value;
+    }
+    
+    /* 
+     * This gets used, by the default UndoManagers supplied by UndoUtils,
+     * to check that a submitted undo/redo matches the change reported. 
+     */
+    public boolean equals( Object other )
+    {
+        if( skipStyleComparison && other instanceof RichTextChange )
+        {
+            PlainTextChange otherChange = ((RichTextChange) other).toPlainTextChange();
+            boolean matches = toPlainTextChange().equals( otherChange );
+            if ( ! matches ) System.err.println(
+                "Plain text comparison mismatch caused by text change"
+                +" during undo manager suspension (styling ignored)."
+            );
+            return matches;
+        }
+
+        return super.equals( other );
+    }
 }


### PR DESCRIPTION
Relates to #903 Unexpected change in UndoManager

When a text style is changed while the undo manager is suspended then it is expected that undo or redo can occur afterwards without the undo manger complaining about any style differences it may encounter.