### PR TITLE
Fix scrollbar jump

### DIFF
--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/ParagraphIndexMappingTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/ParagraphIndexMappingTests.java
@@ -31,6 +31,21 @@ public class ParagraphIndexMappingTests extends InlineCssTextAreaAppTest {
     }
 
     @Test
+    public void all_par_to_visible_par_index_after_replace() {
+        interact(() -> {
+            area.clear();
+            area.replaceText( "123\nabc" );
+        });
+
+        interact(() -> area.replaceText( "123\nxyz" ));
+
+        interact(() -> {
+            assertEquals(Optional.of(1), area.allParToVisibleParIndex(1));
+            assertEquals(Optional.of(0), area.allParToVisibleParIndex(0));
+        });
+    }
+
+    @Test
     public void visible_par_to_all_par_index_is_correct() {
         interact(() -> area.showParagraphAtTop(0));
         assertEquals(0, area.visibleParToAllParIndex(0));

--- a/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/ReplaceTextTests.java
+++ b/richtextfx/src/integrationTest/java/org/fxmisc/richtext/api/ReplaceTextTests.java
@@ -1,9 +1,36 @@
 package org.fxmisc.richtext.api;
 
 import org.fxmisc.richtext.InlineCssTextAreaAppTest;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 public class ReplaceTextTests extends InlineCssTextAreaAppTest {
+
+    @Test
+    public void replaceText_does_not_cause_index_out_of_bounds_exception()
+    {
+        interact( () ->
+        {
+            String test = "abc\n";
+            area.replaceText( test );
+            area.insertText( 0, test +"def\n" );
+
+            // An IndexOutOfBoundsException occurs when trimming MaterializedListModification
+            // in GenericEditableStyledDocumentBase.ParagraphList.observeInputs()
+            area.replaceText( test );
+            assertEquals( test, area.getText() );
+            
+            area.clear();
+            area.replaceText( test );
+            area.appendText( test +"def" );
+            
+            // An IndexOutOfBoundsException occurs when trimming MaterializedListModification
+            // in GenericEditableStyledDocumentBase.ParagraphList.observeInputs()
+            area.replaceText( test +"def" );
+            assertEquals( test +"def", area.getText() );
+        });
+
+    }
 
     @Test
     public void deselect_before_replaceText_does_not_cause_index_out_of_bounds_exception()

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -864,10 +864,15 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                     getParagraphs().size() - 1, allParIndex)
             );
         }
-        Paragraph<PS, SEG, S> p = getParagraph(allParIndex);
-        for (int index = 0; index < getVisibleParagraphs().size(); index++) {
-            if (getVisibleParagraphs().get(index) == p) {
-                return Optional.of(index);
+        List<Cell<Paragraph<PS, SEG, S>, ParagraphBox<PS, SEG, S>>> visibleList = virtualFlow.visibleCells();
+        int firstVisibleParIndex = visibleList.get( 0 ).getNode().getIndex();
+        int targetIndex = allParIndex - firstVisibleParIndex;
+        
+        if ( allParIndex >= firstVisibleParIndex && targetIndex < visibleList.size() )
+        {
+            if ( visibleList.get( targetIndex ).getNode().getIndex() == allParIndex )
+            {
+                return Optional.of( targetIndex );
             }
         }
         return Optional.empty();

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -884,13 +884,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                     getVisibleParagraphs().size() - 1, visibleParIndex)
             );
         }
-        Paragraph<PS, SEG, S> visibleP = getVisibleParagraphs().get(visibleParIndex);
-        for (int index = 0; index < getParagraphs().size(); index++) {
-            if (getParagraph(index) == visibleP) {
-                return index;
-            }
-        }
-        throw new AssertionError("Unreachable code");
+        return virtualFlow.visibleCells().get( visibleParIndex ).getNode().getIndex();
     }
 
     @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocumentBase.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocumentBase.java
@@ -46,7 +46,7 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
             return parChangesList.subscribe(list -> {
                 ListChangeAccumulator<Paragraph<PS, SEG, S>> accumulator = new ListChangeAccumulator<>();
                 for (MaterializedListModification<Paragraph<PS, SEG, S>> mod : list) {
-                    mod = trim(mod);
+                    mod = mod.trim();
 
                     // add the quasiListModification itself, not as a quasiListChange, in case some overlap
                     accumulator.add(QuasiListModification.create(mod.getFrom(), mod.getRemoved(), mod.getAddedSize()));
@@ -221,72 +221,4 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
         });
     }
 
-    /**
-     * Copy of org.reactfx.collection.MaterializedListModification.trim()
-     * that uses reference comparison instead of equals().
-     */
-    private MaterializedListModification<Paragraph<PS, SEG, S>> trim(MaterializedListModification<Paragraph<PS, SEG, S>> mod) {
-        return commonPrefixSuffixLengths(mod.getRemoved(), mod.getAdded()).map((pref, suff) -> {
-            if(pref == 0 && suff == 0) {
-                return mod;
-            } else {
-                return MaterializedListModification.create(
-                        mod.getFrom() + pref,
-                        mod.getRemoved().subList(pref, mod.getRemovedSize() - suff),
-                        mod.getAdded().subList(pref, mod.getAddedSize() - suff));
-            }
-        });
-    }
-
-    /**
-     * Copy of org.reactfx.util.Lists.commonPrefixSuffixLengths()
-     * that uses reference comparison instead of equals().
-     */
-    private static Tuple2<Integer, Integer> commonPrefixSuffixLengths(List<?> l1, List<?> l2) {
-        int n1 = l1.size();
-        int n2 = l2.size();
-
-        if(n1 == 0 || n2 == 0) {
-            return Tuples.t(0, 0);
-        }
-
-        int pref = commonPrefixLength(l1, l2);
-        if(pref == n1 || pref == n2) {
-            return Tuples.t(pref, 0);
-        }
-
-        int suff = commonSuffixLength(l1, l2);
-
-        return Tuples.t(pref, suff);
-    }
-
-    /**
-     * Copy of org.reactfx.util.Lists.commonPrefixLength()
-     * that uses reference comparison instead of equals().
-     */
-    private static int commonPrefixLength(List<?> l, List<?> m) {
-        ListIterator<?> i = l.listIterator();
-        ListIterator<?> j = m.listIterator();
-        while(i.hasNext() && j.hasNext()) {
-            if(i.next() != j.next()) {
-                return i.nextIndex() - 1;
-            }
-        }
-        return i.nextIndex();
-    }
-
-    /**
-     * Copy of org.reactfx.util.Lists.commonSuffixLength()
-     * that uses reference comparison instead of equals().
-     */
-    private static int commonSuffixLength(List<?> l, List<?> m) {
-        ListIterator<?> i = l.listIterator(l.size());
-        ListIterator<?> j = m.listIterator(m.size());
-        while(i.hasPrevious() && j.hasPrevious()) {
-            if(i.previous() != j.previous()) {
-                return l.size() - i.nextIndex() - 1;
-            }
-        }
-        return l.size() - i.nextIndex();
-    }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocumentBase.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/GenericEditableStyledDocumentBase.java
@@ -46,7 +46,7 @@ class GenericEditableStyledDocumentBase<PS, SEG, S> implements EditableStyledDoc
             return parChangesList.subscribe(list -> {
                 ListChangeAccumulator<Paragraph<PS, SEG, S>> accumulator = new ListChangeAccumulator<>();
                 for (MaterializedListModification<Paragraph<PS, SEG, S>> mod : list) {
-                    mod = mod.trim();
+                	try { mod = mod.trim(); } catch ( IndexOutOfBoundsException EX ) {}
 
                     // add the quasiListModification itself, not as a quasiListChange, in case some overlap
                     accumulator.add(QuasiListModification.create(mod.getFrom(), mod.getRemoved(), mod.getAddedSize()));


### PR DESCRIPTION
Fixes #913 which was introduced through PR #795 

This PR reverts the 795 change and implements a more robust and direct method for determining the visible paragraph index or the 'global' paragraph index, instead of using comparison loops. (Resolves #777)

795 also addressed #788 for which this PR adds a test and simply catches the exception for this corner case.