### PR TITLE
Added getLocale and setLocale for BreakIterator use.

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/Caret.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/Caret.java
@@ -184,11 +184,11 @@ public interface Caret {
     void moveBreaksForwards(int numOfBreaks, BreakIterator breakIterator);
 
     default void moveWordBreaksForwards(int numOfWordBreaks) {
-        moveBreaksForwards(numOfWordBreaks, BreakIterator.getWordInstance());
+        moveBreaksForwards(numOfWordBreaks, BreakIterator.getWordInstance( getArea().getLocale() ));
     }
 
     default void moveSentenceBreaksForwards(int numOfSentenceBreaks) {
-        moveBreaksForwards(numOfSentenceBreaks, BreakIterator.getSentenceInstance());
+        moveBreaksForwards(numOfSentenceBreaks, BreakIterator.getSentenceInstance( getArea().getLocale() ));
     }
 
     /**
@@ -197,11 +197,11 @@ public interface Caret {
     void moveBreaksBackwards(int numOfBreaks, BreakIterator breakIterator);
 
     default void moveWordBreaksBackwards(int numOfWordBreaks) {
-        moveBreaksBackwards(numOfWordBreaks, BreakIterator.getWordInstance());
+        moveBreaksBackwards(numOfWordBreaks, BreakIterator.getWordInstance( getArea().getLocale() ));
     }
 
     default void moveSentenceBreaksBackwards(int numOfSentenceBreaks) {
-        moveBreaksBackwards(numOfSentenceBreaks, BreakIterator.getSentenceInstance());
+        moveBreaksBackwards(numOfSentenceBreaks, BreakIterator.getSentenceInstance( getArea().getLocale() ));
     }
 
     /**

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CaretSelectionBindImpl.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CaretSelectionBindImpl.java
@@ -335,7 +335,7 @@ final class CaretSelectionBindImpl<PS, SEG, S> implements CaretSelectionBind<PS,
             return;
         }
 
-        BreakIterator breakIterator = BreakIterator.getWordInstance();
+        BreakIterator breakIterator = BreakIterator.getWordInstance( getArea().getLocale() );
         breakIterator.setText(getArea().getText());
 
         int start = calculatePositionViaBreakingBackwards(1, breakIterator, wordPositionInArea);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
@@ -63,7 +63,7 @@ public class CodeArea extends StyleClassedTextArea {
         int position = csb.getColumnPosition(); 
         
         String paragraphText = getText( paragraph );
-        BreakIterator breakIterator = BreakIterator.getWordInstance();
+        BreakIterator breakIterator = BreakIterator.getWordInstance( getLocale() );
         breakIterator.setText( paragraphText );
 
         breakIterator.preceding( position );

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -7,6 +7,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -352,6 +353,18 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     @Override public void setUndoManager(UndoManager undoManager) {
         this.undoManager.close();
         this.undoManager = undoManager != null ? undoManager : UndoUtils.noOpUndoManager();
+    }
+
+    private Locale textLocale = Locale.getDefault();
+    /**
+     * This is used to determine word and sentence breaks while navigating or selecting.
+     * Override this method if your paragraph or text style accommodates Locales as well.
+     * @return Locale.getDefault() by default
+     */
+    @Override
+    public Locale getLocale() { return textLocale; }
+    public void setLocale( Locale editorLocale ) {
+        textLocale = editorLocale;
     }
 
     private final ObjectProperty<Duration> mouseOverTextDelay = new SimpleObjectProperty<>(null);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/NavigationActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/NavigationActions.java
@@ -102,7 +102,7 @@ public interface NavigationActions<PS, SEG, S> extends TextEditingArea<PS, SEG, 
             return;
         }
 
-        BreakIterator wordBreakIterator = BreakIterator.getWordInstance();
+        BreakIterator wordBreakIterator = BreakIterator.getWordInstance( getLocale() );
         wordBreakIterator.setText(getText());
         wordBreakIterator.preceding(getCaretPosition());
         for (int i = 1; i < n; i++) {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/SelectionImpl.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/SelectionImpl.java
@@ -382,7 +382,7 @@ public class SelectionImpl<PS, SEG, S> implements Selection<PS, SEG, S>, Compara
             return;
         }
 
-        BreakIterator breakIterator = BreakIterator.getWordInstance();
+        BreakIterator breakIterator = BreakIterator.getWordInstance( getArea().getLocale() );
         breakIterator.setText(area.getText());
         breakIterator.preceding(wordPositionInArea);
         breakIterator.next();

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextEditingArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextEditingArea.java
@@ -8,7 +8,6 @@ import javafx.scene.control.IndexRange;
 import org.fxmisc.richtext.model.EditableStyledDocument;
 import org.fxmisc.richtext.model.Paragraph;
 import org.fxmisc.richtext.model.PlainTextChange;
-import org.fxmisc.richtext.model.Replacement;
 import org.fxmisc.richtext.model.RichTextChange;
 import org.fxmisc.richtext.model.SegmentOps;
 import org.fxmisc.richtext.model.StyledDocument;
@@ -17,6 +16,7 @@ import org.reactfx.SuspendableNo;
 import org.reactfx.value.Var;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -40,6 +40,12 @@ public interface TextEditingArea<PS, SEG, S> {
      */
     default int getLength() { return lengthProperty().getValue(); }
     ObservableValue<Integer> lengthProperty();
+
+    /**
+     * This is used to determine word and sentence breaks while navigating or selecting.
+     * Override this method if your paragraph or text style accommodates Locales as well.
+     */
+    default Locale getLocale() { return Locale.getDefault(); }
 
     /**
      * Text content of this text-editing area.


### PR DESCRIPTION
Closes #851

If locale settings are needed on a per paragraph or sentence basis then make sure that there's some way of storing and retrieving the sentence or paragraph's locale from the text or paragraph's **style**. Then override `getLocale` to access the locale from the style and return it.