### PR TITLE
Follow caret show complete line fix

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1750,6 +1750,16 @@ public class GenericStyledArea<PS, SEG, S> extends Region
             }
         }
 
+        // Addresses https://github.com/FXMisc/RichTextFX/issues/937#issuecomment-674319602
+        if ( parIdx == getParagraphs().size()-1 && cell.getNode().getLineCount() == 1 )
+        {
+            region = new BoundingBox // Correcting the region's height
+            (
+                region.getMinX(), region.getMinY(), region.getWidth(),
+                cell.getNode().getLayoutBounds().getHeight()
+            );
+        }
+
         virtualFlow.show(parIdx, region);
     }
 


### PR DESCRIPTION
Addresses this [comment](https://github.com/FXMisc/RichTextFX/issues/937#issuecomment-674319602) of #937 fixing the last line not being displayed fully by follow caret.
Note that this doesn't fix the NoSuchElementException if highlight is on as reported in the issue.