### PR TITLE
Fix nonwrap line highlighter width

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1236,7 +1236,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                 path.getElements().addListener( (Change<? extends PathElement> chg) -> 
                 {
                     if ( chg.next() && chg.wasAdded() || chg.wasReplaced() ) {
-                        double width = getLayoutBounds().getWidth();
+                        double width = path.getParent().getLayoutBounds().getWidth();
                         // The path is limited to the bounds of the text, so here it's altered to the area's width
                         chg.getAddedSubList().stream().skip(1).limit(2).forEach( ele -> ((LineTo) ele).setX( width ) );
                         // The path can wrap onto another line if enough text is inserted, so here it's trimmed


### PR DESCRIPTION
Addresses a side issue reported at the bottom of this [comment](https://github.com/FXMisc/RichTextFX/issues/937#issuecomment-675846754) where the full line wasn't being highlighted when text wrap is off.
Note that this doesn't fix the primary issue mentioned in the linked comment, nor the NoSuchElementException if highlight is on.