### PR TITLE
Fix multi paragraph insert creation

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/ReadOnlyStyledDocument.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/ReadOnlyStyledDocument.java
@@ -127,6 +127,9 @@ public final class ReadOnlyStyledDocument<PS, SEG, S> implements StyledDocument<
      * @param <S> The type of the style of individual segments.
      */
     public static <PS, SEG, S> ReadOnlyStyledDocument<PS, SEG, S> fromSegment(SEG segment,  PS paragraphStyle, S style, SegmentOps<SEG, S> segmentOps) {
+        if ( segment instanceof String && segmentOps instanceof TextOps ) {
+            return fromString( (String) segment, paragraphStyle, style, (TextOps<SEG,S>) segmentOps );
+        }
         Paragraph<PS, SEG, S> content = new Paragraph<PS, SEG, S>(paragraphStyle, segmentOps, segment, style);
         List<Paragraph<PS, SEG, S>> res = Collections.singletonList(content);
         return new ReadOnlyStyledDocument<>(res);


### PR DESCRIPTION
Fixes issue raised in this [comment](https://github.com/FXMisc/RichTextFX/issues/937#issuecomment-675846754) where line highlighting misbehaves when using `insert` instead of `insertText` to add a multiple paragraph text block in one go. This happened  because the text block wasn't being parsed into paragraphs but was just being added as a single giant "paragraph".