### PR TITLE
Fixed issue with replaceText() not called on rich text changes in BracketHighlighterDemo

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/brackethighlighter/CustomCodeArea.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/brackethighlighter/CustomCodeArea.java
@@ -2,6 +2,7 @@ package org.fxmisc.richtext.demo.brackethighlighter;
 
 import org.fxmisc.richtext.CodeArea;
 import org.fxmisc.richtext.model.EditableStyledDocument;
+import org.fxmisc.richtext.model.StyledDocument;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,13 +35,13 @@ public class CustomCodeArea extends CodeArea {
     }
 
     @Override
-    public void replaceText(int start, int end, String text) {
+    public void replace(int start, int end, StyledDocument<Collection<String>, String, Collection<String>> replacement) {
         // notify all listeners
         for (TextInsertionListener listener : insertionListeners) {
-            listener.codeInserted(start, end, text);
+            listener.codeInserted(start, end, replacement.getText());
         }
 
-        super.replaceText(start, end, text);
+        super.replace(start, end, replacement);
     }
 
 }


### PR DESCRIPTION
This PR fixes the issue that brackets do not clear on rich text changes in bracket highlighter demo.

Steps to reproduce:
1. Enter the following character sequence `[]` at position 0 (empty code area).
2. Select the entered character sequence `[]` and copy it with keyboard shortcut (copy rich text).
3. Place caret at position 1 in between the two brackets (position 0 and 1 gets highlighted).
4. Paste the copied rich text using keyboard shortcut at position 1 (position 1, 2, and 3 are highlighted).

**Actual result:**
Position 1, 2, and 3 are highlighted

**Expected result:**
Position 1 and 2 are highlighted

**Resolution:**
Overriding `replace(int, int, StyledDocument<PS, SEG, S>)` instead of `replaceText(int, int, String)` fixes this issue.
This is because `replaceText(int, int, String)` is never called for rich text changes.