### PR TITLE
Removed linehighlighter width listener

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1230,23 +1230,14 @@ public class GenericStyledArea<PS, SEG, S> extends Region
             
             lineHighlighter = new LineSelection<>( this, lineHighlighterFill );
             
-            Runnable adjustHighlighterRange = () ->
-            {
-                if ( lineHighlighter != null )
-                {
-                    lineHighlighter.selectCurrentLine();
-                }
-            };
-            
             Consumer<Bounds> caretListener = b -> 
             {
-                if ( b.getMinY() != caretPrevY || getCaretColumn() == 1 ) {
-                	adjustHighlighterRange.run();
+                if ( lineHighlighter != null && (b.getMinY() != caretPrevY || getCaretColumn() == 1) ) {
+                    lineHighlighter.selectCurrentLine();
                     caretPrevY = b.getMinY();
                 }
             };
             
-            widthProperty().addListener( (ob,ov,nv) -> Platform.runLater( adjustHighlighterRange ) );
             caretBoundsProperty().addListener( (ob,ov,nv) -> nv.ifPresent( caretListener ) );
             getCaretBounds().ifPresent( caretListener );
             selectionSet.add( lineHighlighter );


### PR DESCRIPTION
The width listener was causing an NPE, but is also no longer needed due to a previous PR #948 that fits the line highlight shape to the parent's width. This essentially reverts PR #857 without regression.
