### PR TITLE
Paragraph Folding

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/BulletFactory.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/BulletFactory.java
@@ -2,35 +2,68 @@ package org.fxmisc.richtext.demo.richtext;
 
 import java.util.function.IntFunction;
 
-import org.fxmisc.richtext.GenericStyledArea;
-
+import javafx.application.Platform;
 import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Cursor;
 import javafx.scene.Node;
 import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.Label;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Rectangle;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontPosture;
+
+import org.fxmisc.richtext.demo.richtext.RichTextDemo.FoldableStyledArea;
 
 public class BulletFactory implements IntFunction<Node>
 {
-    private GenericStyledArea<ParStyle,?,?> area;
-    
-    public BulletFactory( GenericStyledArea<ParStyle,?,?> area )
+    private FoldableStyledArea area;
+
+    private static final Font DEFAULT_FONT = Font.font("monospace", FontPosture.ITALIC, 13);
+
+    public BulletFactory( FoldableStyledArea area )
     {
+        area.getParagraphs().sizeProperty().addListener( (ob,ov,nv) -> {
+            if ( nv <= ov ) Platform.runLater( () -> deleteParagraphCheck() );
+            else  Platform.runLater( () -> insertParagraphCheck() );
+        });
         this.area = area;
-    } 
+    }
 
     @Override
     public Node apply( int value )
     {
-        if ( value < 0 ) return null;
-        
         ParStyle ps = area.getParagraph( value ).getParagraphStyle();
-        if ( ! ps.indent.isPresent() ) return null;
+        return createGraphic( ps, value );
+    }
 
-        return createBullet( ps.indent.get() );
+    private Node createGraphic( ParStyle ps, int idx )
+    {
+        Label foldIndicator = new Label( "  " );
+        VBox.setVgrow( foldIndicator, Priority.ALWAYS );
+        foldIndicator.setMaxHeight( Double.MAX_VALUE );
+        foldIndicator.setAlignment( Pos.TOP_LEFT );
+        foldIndicator.setFont( DEFAULT_FONT );
+
+        if ( area.getParagraphs().size() > idx+1 ) {
+            if ( area.getParagraph( idx+1 ).getParagraphStyle().isFolded() && ! ps.isFolded() ) {
+                foldIndicator.setOnMouseClicked( ME -> area.unfoldParagraphs( idx ) );
+                foldIndicator.getStyleClass().add( "fold-indicator" );
+                foldIndicator.setCursor( Cursor.HAND );
+                foldIndicator.setText( "+ " );
+            }
+        }
+
+        if ( ps.isIndented() && ! ps.isFolded() ) {
+            foldIndicator.setGraphic( createBullet( ps.getIndent() ) );
+            foldIndicator.setContentDisplay( ContentDisplay.RIGHT );
+        }
+
+        return new VBox( 0, foldIndicator );
     }
 
     private Node createBullet(Indent in) {
@@ -68,10 +101,49 @@ public class BulletFactory implements IntFunction<Node>
                 }
                 break;
         }
-        
-        Label l = new Label( " ", result );
-        l.setPadding( new Insets( 0, 0, 0, in.level*in.width ) );
-        l.setContentDisplay( ContentDisplay.LEFT );
-        return new VBox( 0, l );
+
+        Label bullet = new Label( " ", result );
+        bullet.setPadding( new Insets( 0, 0, 0, in.level*in.width ) );
+        bullet.setContentDisplay( ContentDisplay.LEFT );
+        return bullet;
+    }
+
+    private void deleteParagraphCheck()
+    {
+        int p = area.getCurrentParagraph();
+        // Was the deleted paragraph in the viewport ?
+        if ( p >= area.firstVisibleParToAllParIndex() && p <= area.lastVisibleParToAllParIndex() )
+        {
+            int col = area.getCaretColumn();
+            // Delete was pressed on an empty paragraph, and so the cursor is now at the start of the next paragraph.
+            if ( col == 0 ) {
+                // Check if the now current paragraph is folded.
+                if ( area.getParagraph( p ).getParagraphStyle().isFolded() ) {
+                    p = Math.max( p-1, 0 );              // Adjust to previous paragraph.
+                    area.recreateParagraphGraphic( p );  // Show fold/unfold indicator on previous paragraph.
+                    area.moveTo( p, 0 );                 // Move cursor to previous paragraph.
+                }
+            }
+            // Backspace was pressed on an empty paragraph, and so the cursor is now at the end of the previous paragraph.
+            else if ( col == area.getParagraph( p ).length() ) {
+                area.recreateParagraphGraphic( p ); // Shows fold/unfold indicator on current paragraph if needed.
+            }
+            // In all other cases the paragraph graphic is created/updated automatically.
+        }
+    }
+
+    private void insertParagraphCheck()
+    {
+        int p = area.getCurrentParagraph();
+        // Is the inserted paragraph in the viewport ?
+        if ( p > area.firstVisibleParToAllParIndex() && p <= area.lastVisibleParToAllParIndex() ) {
+            // Check limits, as p-1 and p+1 are accessed ...
+            if ( p > 0 && p+1 < area.getParagraphs().size() ) {
+                // Now check if the inserted paragraph is before a folded block ?
+                if ( area.getParagraph( p+1 ).getParagraphStyle().isFolded() ) {
+                    area.recreateParagraphGraphic( p-1 ); // Remove the unfold indicator.
+                }
+            }
+        }
     }
 }

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/ParStyle.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/ParStyle.java
@@ -36,13 +36,17 @@ class ParStyle {
         public void encode(DataOutputStream os, ParStyle t) throws IOException {
             OPT_ALIGNMENT_CODEC.encode(os, t.alignment);
             OPT_COLOR_CODEC.encode(os, t.backgroundColor);
+            os.writeInt( t.indent.map( i -> Integer.valueOf( i.level ) ).orElse( 0 ) );
+            os.writeInt( t.foldCount );
         }
 
         @Override
         public ParStyle decode(DataInputStream is) throws IOException {
             return new ParStyle(
                     OPT_ALIGNMENT_CODEC.decode(is),
-                    OPT_COLOR_CODEC.decode(is));
+                    OPT_COLOR_CODEC.decode(is),
+                    Optional.of( new Indent( is.readInt() ) ),
+                    is.readInt() );
         }
 
     };
@@ -52,28 +56,28 @@ class ParStyle {
     public static ParStyle alignRight() { return EMPTY.updateAlignment(RIGHT); }
     public static ParStyle alignJustify() { return EMPTY.updateAlignment(JUSTIFY); }
     public static ParStyle backgroundColor(Color color) { return EMPTY.updateBackgroundColor(color); }
+    public static ParStyle folded() { return EMPTY.updateFold(Boolean.TRUE); }
+    public static ParStyle unfolded() { return EMPTY.updateFold(Boolean.FALSE); }
 
     final Optional<TextAlignment> alignment;
     final Optional<Color> backgroundColor;
     final Optional<Indent> indent;
+    final int foldCount;
 
-    public ParStyle() {
-        this(Optional.empty(), Optional.empty(), Optional.empty());
+    private ParStyle() {
+        this(Optional.empty(), Optional.empty(), Optional.empty(), 0);
     }
 
-    public ParStyle(Optional<TextAlignment> alignment, Optional<Color> backgroundColor) {
-        this(alignment, backgroundColor, Optional.empty());
-    }
-
-    public ParStyle(Optional<TextAlignment> alignment, Optional<Color> backgroundColor, Optional<Indent> indent) {
+    private ParStyle(Optional<TextAlignment> alignment, Optional<Color> backgroundColor, Optional<Indent> indent, int folds) {
         this.alignment = alignment;
         this.backgroundColor = backgroundColor;
+        this.foldCount = folds;
         this.indent = indent;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(alignment, backgroundColor, indent);
+        return Objects.hash(alignment, backgroundColor, indent, foldCount);
     }
 
     @Override
@@ -82,7 +86,8 @@ class ParStyle {
             ParStyle that = (ParStyle) other;
             return Objects.equals(this.alignment, that.alignment) &&
                    Objects.equals(this.backgroundColor, that.backgroundColor) &&
-                   Objects.equals(this.indent, that.indent);
+                   Objects.equals(this.indent, that.indent) &&
+                   this.foldCount == that.foldCount;
         } else {
             return false;
         }
@@ -112,6 +117,8 @@ class ParStyle {
             sb.append("-fx-background-color: " + TextStyle.cssColor(color) + ";");
         });
 
+        if ( foldCount > 0 ) sb.append( "visibility: collapse;" );
+
         return sb.toString();
     }
 
@@ -119,19 +126,20 @@ class ParStyle {
         return new ParStyle(
                 mixin.alignment.isPresent() ? mixin.alignment : alignment,
                 mixin.backgroundColor.isPresent() ? mixin.backgroundColor : backgroundColor,
-                mixin.indent.isPresent() ? mixin.indent : indent );
+                mixin.indent.isPresent() ? mixin.indent : indent,
+                mixin.foldCount + foldCount);
     }
 
     public ParStyle updateAlignment(TextAlignment alignment) {
-        return new ParStyle(Optional.of(alignment), backgroundColor, indent);
+        return new ParStyle(Optional.of(alignment), backgroundColor, indent, foldCount);
     }
 
     public ParStyle updateBackgroundColor(Color backgroundColor) {
-        return new ParStyle(alignment, Optional.of(backgroundColor), indent);
+        return new ParStyle(alignment, Optional.of(backgroundColor), indent, foldCount);
     }
 
     public ParStyle updateIndent(Indent indent) {
-        return new ParStyle(alignment, backgroundColor, Optional.ofNullable(indent));
+        return new ParStyle(alignment, backgroundColor, Optional.ofNullable(indent), foldCount);
     }
 
     public ParStyle increaseIndent() {
@@ -143,4 +151,20 @@ class ParStyle {
            .map( Indent::decrease ).orElse( null ) );
     }
 
+    public Indent getIndent() {
+        return indent.get();
+    }
+
+    public boolean isIndented() {
+        return indent.map( in -> in.level > 0 ).orElse( false );
+    }
+
+    public ParStyle updateFold(boolean fold) {
+        int foldLevels = fold ? foldCount+1 : Math.max( 0, foldCount-1 );
+        return new ParStyle(alignment, backgroundColor, indent, foldLevels);
+    }
+
+    public boolean isFolded() {
+        return foldCount > 0;
+    }
 }

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/RichTextDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/richtext/RichTextDemo.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 import javafx.application.Application;
 import javafx.beans.binding.BooleanBinding;
@@ -29,7 +31,9 @@ import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ColorPicker;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ContextMenu;
 import javafx.scene.control.IndexRange;
+import javafx.scene.control.MenuItem;
 import javafx.scene.control.Separator;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
@@ -71,23 +75,105 @@ public class RichTextDemo extends Application {
         launch(args);
     }
 
-    private final TextOps<String, TextStyle> styledTextOps = SegmentOps.styledTextOps();
-    private final LinkedImageOps<TextStyle> linkedImageOps = new LinkedImageOps<>();
+    private final FoldableStyledArea area = new FoldableStyledArea();
 
-    private final GenericStyledArea<ParStyle, Either<String, LinkedImage>, TextStyle> area =
-            new GenericStyledArea<>(
-                    ParStyle.EMPTY,                                                 // default paragraph style
-                    (paragraph, style) -> paragraph.setStyle(style.toCss()),        // paragraph style setter
+    static class FoldableStyledArea extends GenericStyledArea<ParStyle, Either<String, LinkedImage>, TextStyle>
+    {
+        private final static TextOps<String, TextStyle> styledTextOps = SegmentOps.styledTextOps();
+        private final static LinkedImageOps<TextStyle> linkedImageOps = new LinkedImageOps<>();
 
-                    TextStyle.EMPTY.updateFontSize(12).updateFontFamily("Serif").updateTextColor(Color.BLACK),  // default segment style
-                    styledTextOps._or(linkedImageOps, (s1, s2) -> Optional.empty()),                            // segment operations
-                    seg -> createNode(seg, (text, style) -> text.setStyle(style.toCss())));                     // Node creator and segment style setter
+        public FoldableStyledArea()
+        {
+            super(
+                ParStyle.EMPTY,                                                 // default paragraph style
+                (paragraph, style) -> paragraph.setStyle(style.toCss()),        // paragraph style setter
+                TextStyle.EMPTY.updateFontSize(12).updateFontFamily("Serif").updateTextColor(Color.BLACK),  // default segment style
+                styledTextOps._or(linkedImageOps, (s1, s2) -> Optional.empty()),                            // segment operations
+                seg -> createNode(seg, (text, style) -> text.setStyle(style.toCss())));                     // Node creator and segment style setter
+        }
+
+        private static Node createNode( StyledSegment<Either<String, LinkedImage>, TextStyle> seg,
+                                        BiConsumer<? super TextExt, TextStyle> applyStyle ) {
+            return seg.getSegment().unify(
+                    text -> StyledTextArea.createStyledTextNode(text, seg.getStyle(), applyStyle),
+                    LinkedImage::createNode
+            );
+        }
+
+        public void foldParagraphs( int startPar, int endPar ) {
+            foldParagraphs( startPar, endPar, getAddFoldStyle() );
+        }
+
+        public void foldSelectedParagraphs() {
+            foldSelectedParagraphs( getAddFoldStyle() );
+        }
+
+        public void foldText( int start, int end ) {
+            fold( start, end, getAddFoldStyle() );
+        }
+
+        public void unfoldParagraphs( int startingFromPar ) {
+            unfoldParagraphs( startingFromPar, getFoldStyleCheck(), getRemoveFoldStyle() );
+        }
+
+        public void unfoldText( int startingFromPos ) {
+            startingFromPos = offsetToPosition( startingFromPos, Bias.Backward ).getMajor();
+            unfoldParagraphs( startingFromPos, getFoldStyleCheck(), getRemoveFoldStyle() );
+        }
+
+        protected UnaryOperator<ParStyle> getAddFoldStyle() {
+            return pstyle -> pstyle.updateFold( true );
+        }
+
+        protected UnaryOperator<ParStyle> getRemoveFoldStyle() {
+            return pstyle -> pstyle.updateFold( false );
+        }
+
+        protected Predicate<ParStyle> getFoldStyleCheck() {
+            return pstyle -> pstyle.isFolded();
+        }
+    }
+
+    private class DefaultContextMenu extends ContextMenu
+    {
+        private MenuItem fold, unfold;
+
+        public DefaultContextMenu()
+        {
+            fold = new MenuItem( "Fold selected text" );
+            fold.setOnAction( AE -> { hide(); fold(); } );
+
+            unfold = new MenuItem( "Unfold from cursor" );
+            unfold.setOnAction( AE -> { hide(); unfold(); } );
+
+            getItems().addAll( fold, unfold );
+        }
+
+        /**
+         * Folds multiple lines of selected text, only showing the first line and hiding the rest.
+         */
+        private void fold()
+        {
+            ((FoldableStyledArea) getOwnerNode()).foldSelectedParagraphs();
+        }
+
+        /**
+         * Unfold the CURRENT line/paragraph if it has a fold.
+         */
+        private void unfold()
+        {
+            FoldableStyledArea area = (FoldableStyledArea) getOwnerNode();
+            area.unfoldParagraphs( area.getCurrentParagraph() );
+        }
+    }
+
     {
         area.setWrapText(true);
         area.setStyleCodecs(
                 ParStyle.CODEC,
                 Codec.styledSegmentCodec(Codec.eitherCodec(Codec.STRING_CODEC, LinkedImage.codec()), TextStyle.CODEC));
-        area.setParagraphGraphicFactory( new BulletFactory( area ) );
+        area.setParagraphGraphicFactory( new BulletFactory( area ) );  // and folded paragraph indicator
+        area.setContextMenu( new DefaultContextMenu() );
     }
 
     private Stage mainStage;
@@ -304,14 +390,6 @@ public class RichTextDemo extends Application {
         primaryStage.show();
     }
 
-
-    private Node createNode(StyledSegment<Either<String, LinkedImage>, TextStyle> seg,
-                            BiConsumer<? super TextExt, TextStyle> applyStyle) {
-        return seg.getSegment().unify(
-                text -> StyledTextArea.createStyledTextNode(text, seg.getStyle(), applyStyle),
-                LinkedImage::createNode
-        );
-    }
 
     private Button createButton(String styleClass, Runnable action, String toolTip) {
         Button button = new Button();

--- a/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/InlineCssTextArea.java
@@ -4,6 +4,9 @@ package org.fxmisc.richtext;
 import javafx.beans.NamedArg;
 import javafx.scene.text.TextFlow;
 
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
 import org.fxmisc.richtext.model.Codec;
 import org.fxmisc.richtext.model.EditableStyledDocument;
 import org.fxmisc.richtext.model.ReadOnlyStyledDocument;
@@ -55,4 +58,65 @@ public class InlineCssTextArea extends StyledTextArea<String, String> {
         selectRange(0, 0);
     }
 
+
+    /**
+     * Folds (hides/collapses) paragraphs from <code>startPar</code> to <code>
+     * endPar</code>, "into" (i.e. excluding) the first paragraph of the range.
+     */
+    public void foldParagraphs( int startPar, int endPar ) {
+        foldParagraphs( startPar, endPar, getAddFoldStyle() );
+    }
+
+    /**
+     * Folds (hides/collapses) the currently selected paragraphs,
+     * "into" (i.e. excluding) the first paragraph of the range.
+     */
+    public void foldSelectedParagraphs() {
+        foldSelectedParagraphs( getAddFoldStyle() );
+    }
+
+    /**
+     * Folds (hides/collapses) paragraphs from character position <code>start</code>
+     * to <code>end</code>, "into" (i.e. excluding) the first paragraph of the range.
+     */
+    public void foldText( int start, int end ) {
+        fold( start, end, getAddFoldStyle() );
+    }
+
+    /**
+     * Unfolds paragraphs <code>startingFromPar</code> onwards for the currently folded block.
+     */
+    public void unfoldParagraphs( int startingFromPar ) {
+        unfoldParagraphs( startingFromPar, getFoldStyleCheck(), getRemoveFoldStyle() );
+    }
+
+    /**
+     * Unfolds text <code>startingFromPos</code> onwards for the currently folded block.
+     */
+    public void unfoldText( int startingFromPos ) {
+    	startingFromPos = offsetToPosition( startingFromPos, Bias.Backward ).getMajor();
+        unfoldParagraphs( startingFromPos, getFoldStyleCheck(), getRemoveFoldStyle() );
+    }
+
+
+    /**
+     * @return a Predicate that given a paragraph style, returns true if it includes folding.
+     */
+    protected Predicate<String> getFoldStyleCheck() {
+        return pstyle -> pstyle != null && pstyle.contains( "collapse" );
+    }
+
+    /**
+     * @return a UnaryOperator that given a paragraph style, returns a String that includes fold styling.
+     */
+    protected UnaryOperator<String> getAddFoldStyle() {
+        return pstyle -> "visibility: collapse;"+ (pstyle != null ? pstyle : "");
+    }
+
+    /**
+     * @return a UnaryOperator that given a paragraph style, returns a String that excludes fold styling.
+     */
+    protected UnaryOperator<String> getRemoveFoldStyle() {
+        return pstyle -> pstyle.replaceFirst( "visibility: collapse;", "" );
+    }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/LineNumberFactory.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/LineNumberFactory.java
@@ -117,7 +117,8 @@ public class LineNumberFactory<PS> implements IntFunction<Node> {
             lineNo.setGraphic( foldIndicator );
 
             if ( area.getParagraphs().size() > idx+1 ) {
-                if ( isFoldedCheck.test( area.getParagraph( idx+1 ).getParagraphStyle() ) ) {
+                if ( isFoldedCheck.test( area.getParagraph( idx+1 ).getParagraphStyle() )
+                && ! isFoldedCheck.test( area.getParagraph( idx ).getParagraphStyle() ) ) {
                     foldIndicator.setOnMouseClicked( ME -> area.unfoldParagraphs
                     (
                         idx, isFoldedCheck, removeFoldStyle

--- a/richtextfx/src/main/java/org/fxmisc/richtext/LineNumberFactory.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/LineNumberFactory.java
@@ -1,10 +1,15 @@
 package org.fxmisc.richtext;
 
 import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
+import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Cursor;
 import javafx.scene.Node;
+import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
@@ -17,10 +22,10 @@ import org.reactfx.collection.LiveList;
 import org.reactfx.value.Val;
 
 /**
- * Graphic factory that produces labels containing line numbers.
- * To customize appearance, use {@code .lineno} style class in CSS stylesheets.
+ * Graphic factory that produces labels containing line numbers and a "+" to indicate folded paragraphs.
+ * To customize appearance, use {@code .lineno} and {@code .fold-indicator} style classes in CSS stylesheets.
  */
-public class LineNumberFactory implements IntFunction<Node> {
+public class LineNumberFactory<PS> implements IntFunction<Node> {
 
     private static final Insets DEFAULT_INSETS = new Insets(0.0, 5.0, 0.0, 5.0);
     private static final Paint DEFAULT_TEXT_FILL = Color.web("#666");
@@ -33,20 +38,60 @@ public class LineNumberFactory implements IntFunction<Node> {
         return get(area, digits -> "%1$" + digits + "s");
     }
 
-    public static IntFunction<Node> get(
-            GenericStyledArea<?, ?, ?> area,
-            IntFunction<String> format) {
-        return new LineNumberFactory(area, format);
+    public static <PS> IntFunction<Node> get( GenericStyledArea<PS, ?, ?> area, IntFunction<String> format )
+    {
+        if ( area instanceof StyleClassedTextArea ) {
+            StyleClassedTextArea classArea = (StyleClassedTextArea) area;
+            return get( classArea, format, classArea.getFoldStyleCheck(), classArea.getRemoveFoldStyle() );
+        }
+        else if ( area instanceof InlineCssTextArea ) {
+            InlineCssTextArea inlineArea = (InlineCssTextArea) area;
+            return get( inlineArea, format, inlineArea.getFoldStyleCheck(), inlineArea.getRemoveFoldStyle() );
+        }
+        return get( area, format, null, null );
+    }
+
+    /**
+     * Use this if you extended GenericStyledArea for your own text area and you're using paragraph folding.
+     *
+     * @param <PS> The paragraph style type being used by the text area
+     * @param format Given an int convert to a String for the line number.
+     * @param isFolded Given a paragraph style PS check if it's folded.
+     * @param removeFoldStyle Given a paragraph style PS, return a <b>new</b> PS that excludes fold styling.
+     */
+    public static <PS> IntFunction<Node> get(
+            GenericStyledArea<PS, ?, ?> area,
+            IntFunction<String> format,
+            Predicate<PS> isFolded,
+            UnaryOperator<PS> removeFoldStyle )
+    {
+        return new LineNumberFactory<>( area, format, isFolded, removeFoldStyle );
     }
 
     private final Val<Integer> nParagraphs;
     private final IntFunction<String> format;
+    private final GenericStyledArea<PS, ?, ?> area;
+    private final UnaryOperator<PS> removeFoldStyle;
+    private final Predicate<PS> isFoldedCheck;
 
     private LineNumberFactory(
-            GenericStyledArea<?, ?, ?> area,
-            IntFunction<String> format) {
+            GenericStyledArea<PS, ?, ?> area,
+            IntFunction<String> format,
+            Predicate<PS> isFolded,
+            UnaryOperator<PS> removeFoldStyle )
+    {
         nParagraphs = LiveList.sizeOf(area.getParagraphs());
+        this.removeFoldStyle = removeFoldStyle;
+        this.isFoldedCheck = isFolded;
         this.format = format;
+        this.area = area;
+
+        if ( isFoldedCheck != null ) {
+            area.getParagraphs().sizeProperty().addListener( (ob,ov,nv) -> {
+                if ( nv <= ov ) Platform.runLater( () -> deleteParagraphCheck() );
+                else  Platform.runLater( () -> insertParagraphCheck() );
+            });
+        }
     }
 
     @Override
@@ -65,6 +110,25 @@ public class LineNumberFactory implements IntFunction<Node> {
         // when lineNo is removed from scene
         lineNo.textProperty().bind(formatted.conditionOnShowing(lineNo));
 
+        if ( isFoldedCheck != null )
+        {
+            Label foldIndicator = new Label( " " );
+            lineNo.setContentDisplay( ContentDisplay.RIGHT );
+            lineNo.setGraphic( foldIndicator );
+
+            if ( area.getParagraphs().size() > idx+1 ) {
+                if ( isFoldedCheck.test( area.getParagraph( idx+1 ).getParagraphStyle() ) ) {
+                    foldIndicator.setOnMouseClicked( ME -> area.unfoldParagraphs
+                    (
+                        idx, isFoldedCheck, removeFoldStyle
+                    ));
+                    foldIndicator.getStyleClass().add( "fold-indicator" );
+                    foldIndicator.setCursor( Cursor.HAND );
+                    foldIndicator.setText( "+" );
+                }
+            }
+        }
+
         return lineNo;
     }
 
@@ -72,4 +136,44 @@ public class LineNumberFactory implements IntFunction<Node> {
         int digits = (int) Math.floor(Math.log10(max)) + 1;
         return String.format(format.apply(digits), x);
     }
+
+    private void deleteParagraphCheck()
+    {
+        int p = area.getCurrentParagraph();
+        // Was the deleted paragraph in the viewport ?
+        if ( p >= area.firstVisibleParToAllParIndex() && p <= area.lastVisibleParToAllParIndex() )
+        {
+            int col = area.getCaretColumn();
+            // Delete was pressed on an empty paragraph, and so the cursor is now at the start of the next paragraph.
+            if ( col == 0 ) {
+                // Check if the now current paragraph is folded.
+                if ( isFoldedCheck.test( area.getParagraph( p ).getParagraphStyle() ) ) {
+                    p = Math.max( p-1, 0 );              // Adjust to previous paragraph.
+                    area.recreateParagraphGraphic( p );  // Show fold/unfold indicator on previous paragraph.
+                    area.moveTo( p, 0 );                 // Move cursor to previous paragraph.
+                }
+            }
+            // Backspace was pressed on an empty paragraph, and so the cursor is now at the end of the previous paragraph.
+            else if ( col == area.getParagraph( p ).length() ) {
+                area.recreateParagraphGraphic( p ); // Shows fold/unfold indicator on current paragraph if needed.
+            }
+            // In all other cases the paragraph graphic is created/updated automatically.
+        }
+    }
+
+    private void insertParagraphCheck()
+    {
+        int p = area.getCurrentParagraph();
+        // Is the inserted paragraph in the viewport ?
+        if ( p > area.firstVisibleParToAllParIndex() && p <= area.lastVisibleParToAllParIndex() ) {
+            // Check limits, as p-1 and p+1 are accessed ...
+            if ( p > 0 && p+1 < area.getParagraphs().size() ) {
+                // Now check if the inserted paragraph is before a folded block ?
+                if ( isFoldedCheck.test( area.getParagraph( p+1 ).getParagraphStyle() ) ) {
+                    area.recreateParagraphGraphic( p-1 ); // Remove the unfold indicator.
+                }
+            }
+        }
+    }
+
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -78,6 +78,9 @@ class ParagraphBox<PS, SEG, S> extends Region {
         wrapText.addListener((obs, old, w) -> requestLayout());
     }
 
+    private final Val<Boolean> isFolded;
+    public boolean isFolded() { return isFolded.getValue(); }
+
     private final Var<Integer> index;
     public Val<Integer> indexProperty() { return index; }
     public void setIndex(int index) { this.index.setValue(index); }
@@ -94,6 +97,7 @@ class ParagraphBox<PS, SEG, S> extends Region {
         this.getStyleClass().add("paragraph-box");
         this.text = new ParagraphText<>(par, nodeFactory);
         applyParagraphStyle.accept(this.text, par.getParagraphStyle());
+        isFolded = Val.wrap( text.visibleProperty().not() );
         
         // start at -1 so that the first time it is displayed, the caret at pos 0 is not
         // accidentally removed from its parent and moved to this node's ParagraphText
@@ -235,6 +239,7 @@ class ParagraphBox<PS, SEG, S> extends Region {
 
     @Override
     protected double computePrefHeight(double width) {
+        if ( isFolded.getValue() ) return 0.0;
         Insets insets = getInsets();
         double overhead = getGraphicPrefWidth() + insets.getLeft() + insets.getRight();
         return text.prefHeight(width - overhead) + insets.getTop() + insets.getBottom() + text.getLineSpacing();

--- a/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/StyleClassedTextArea.java
@@ -1,7 +1,10 @@
 package org.fxmisc.richtext;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 import javafx.beans.NamedArg;
 import org.fxmisc.richtext.model.Codec;
@@ -67,5 +70,77 @@ public class StyleClassedTextArea extends StyledTextArea<Collection<String>, Col
      */
     public void setStyleClass( int from, int to, String styleClass ) {
         setStyle( from, to, Collections.singletonList( styleClass ) );
+    }
+
+
+    /**
+     * Folds (hides/collapses) paragraphs from <code>startPar</code> to <code>
+     * endPar</code>, "into" (i.e. excluding) the first paragraph of the range.
+     */
+    public void foldParagraphs( int startPar, int endPar ) {
+        foldParagraphs( startPar, endPar, getAddFoldStyle() );
+    }
+
+    /**
+     * Folds (hides/collapses) the currently selected paragraphs,
+     * "into" (i.e. excluding) the first paragraph of the range.
+     */
+    public void foldSelectedParagraphs() {
+        foldSelectedParagraphs( getAddFoldStyle() );
+    }
+
+    /**
+     * Folds (hides/collapses) paragraphs from character position <code>start</code>
+     * to <code>end</code>, "into" (i.e. excluding) the first paragraph of the range.
+     */
+    public void foldText( int start, int end ) {
+        fold( start, end, getAddFoldStyle() );
+    }
+
+    /**
+     * Unfolds paragraphs <code>startingFrom</code> onwards for the currently folded block.
+     */
+    public void unfoldParagraphs( int startingFromPar ) {
+        unfoldParagraphs( startingFromPar, getFoldStyleCheck(), getRemoveFoldStyle() );
+    }
+
+    /**
+     * Unfolds text <code>startingFromPos</code> onwards for the currently folded block.
+     */
+    public void unfoldText( int startingFromPos ) {
+    	startingFromPos = offsetToPosition( startingFromPos, Bias.Backward ).getMajor();
+        unfoldParagraphs( startingFromPos, getFoldStyleCheck(), getRemoveFoldStyle() );
+    }
+
+
+    /**
+     * @return a Predicate that given a paragraph style, returns true if it includes folding.
+     */
+    protected Predicate<Collection<String>> getFoldStyleCheck() {
+        return styleList -> styleList != null && styleList.contains( "collapse" );
+    }
+
+    /**
+     * @return a UnaryOperator that given a paragraph style, returns a style that includes fold styling.
+     */
+    protected UnaryOperator<Collection<String>> getAddFoldStyle() {
+        return styleList -> {
+            styleList = new ArrayList<>( styleList );
+            // "collapse" is in styled-text-area.css:
+            // .collapse { visibility: false; }
+            styleList.add( "collapse" );
+            return styleList;
+        };
+    }
+
+    /**
+     * @return a UnaryOperator that given a paragraph style, returns a style that excludes fold styling.
+     */
+    protected UnaryOperator<Collection<String>> getRemoveFoldStyle() {
+        return styleList -> {
+            styleList = new ArrayList<>( styleList );
+            styleList.remove( "collapse" );
+            return styleList;
+        };
     }
 }

--- a/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-area.css
+++ b/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-area.css
@@ -14,3 +14,12 @@
     -rtfx-blink-rate: 500ms;
     -fx-stroke-width: 1.0;
 }
+
+/* For folding/hiding paragraphs. It's applied to TextFlow. */
+.collapse { visibility: collapse; }
+
+/* For LineNumberFactory, it's applied to Label. */
+.fold-indicator {
+    -fx-font-weight: bold;
+    -fx-text-fill: blue;
+}


### PR DESCRIPTION
This PR implements Paragraph Folding, resolves #107 and closes #955

Folded/collapsed paragraphs can be copied, pasted, and saved. A section of text containing a fold can also be folded without losing the contained fold, and each layer only unfolds itself. Any folded/collapsed text is still part of the document and can be manipulated as usual. The LineNumberFactory has also been modified to show a clickable "+" symbol on the line before a fold.

For historical purposes or for whoever cares to scrutinize how this was implemented and to defend any WTF thoughts, some explanatory notes are needed. Rest assured that careful consideration has been given and although not necessarily the best way of accomplishing folding it wasn't just arbitrarily or haphazardly slapped on even though it may appear that way.

If you are familiar with the RichTextFX architecture then you may have thought that the natural place for this feature to be implemented would have been through the Paragraph class. The problem however with adding extra state to Paragraph is that it would then become incompatible with any RichTextFX documents previously saved via the inbuilt Codecs and loading those documents would fail. So in order to maintain maximum backward compatibility and not have the added complexity to also modify the codecs to handle multiple save files an alternative, less elegant and unconventional approach had to be taken.

The idea is to leverage RichTextFX's ability to have/apply paragraph level styling to accomplish folding. The problem with this approach though is that a paragraph style object is generic and not a predefined object of any sort, there's not even an interface. This means that any methods created for folding/unfolding needs to have some function/operator passed to it to manipulate whatever paragraph style object is being used. The four generic methods added to GenericStyledArea are all really just convenience methods doing the heavy-lifting and technically one doesn't have to use them at all (see last paragraph). They are really just API to say "Hey paragraph folding is possible if you're interested".

These four methods in GenericStyledArea are marked as protected because of their generic signatures and have simpler public representations in InlineCssTextArea and StyleClassedTextArea. Any DRY purists/idealists should be aware that code duplication was kept intentionally (:gasp:) in order to aid context (i.e. not have related code separated) and also not to expose methods that have no business being public (which would have had to be the case if an interface with default methods had been used). The duplication resulted as a natural code evolution of enabling LineNumberFactory to support folding.

If you use InlineCssTextArea, StyleClassedTextArea, or CodeArea then you are good to go and can just use the API to fold/collapse paragraphs of text. However if you have extended GenericStyledArea and would like to use folding then you'll need to do some additional coding. First read the JavaDocs for the fold/unfold methods in GenericStyledArea and then see how InlineCssTextArea, StyleClassedTextArea, or RichTextDemo have implemented the necessary function/operators and use that to guide your own implementation. (Also look at LineNumberFactory and demo.richtext.BulletFactory if applicable to your use case.)

You can also just do your own thing from scratch if you want by taking note of the following. Historically paragraph styles are applied to TextFlow objects via the applyParagraphStyle BiConsumer (supplied in the constructor to GenericStyledArea). So essentially the way you get a paragraph to collapse is simply by setting its _visibility_ to false, through the applyParagraphStyle BiConsumer, when a paragraph style indicates to do so. There is a preexisting JavaFX CSS tag for this that has a valid value of "_collapse_" (equivalent to false). So `txtFlow.setStyle("visibility: collapse;")` or `txtFlow.setStyle("visibility: false;")`, or `txtFlow.getStyleClass().add("collapse")` where `.collapse { visibility: false; }` would trigger the paragraph to be folded by RichTextFX.