### PR TITLE
Realign controlKeysFilter with previous behavior

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledAreaBehavior.java
@@ -180,7 +180,7 @@ class GenericStyledAreaBehavior {
                 if (e.isControlDown() && e.isAltDown() && !e.isMetaDown() && e.getCharacter().length() == 1
                 	    && e.getCharacter().getBytes()[0] != 0) return true;
                 
-                return !e.isMetaDown() && (!e.isControlDown() || e.isAltDown());
+                return !e.isControlDown() && !e.isAltDown() && !e.isMetaDown();
             }
         	return !e.isControlDown() && !e.isMetaDown();
         };

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledAreaBehavior.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledAreaBehavior.java
@@ -179,8 +179,10 @@ class GenericStyledAreaBehavior {
                 //Note that this is how several IDEs such JetBrains IDEs or Eclipse behave.
                 if (e.isControlDown() && e.isAltDown() && !e.isMetaDown() && e.getCharacter().length() == 1
                 	    && e.getCharacter().getBytes()[0] != 0) return true;
+                
+                return !e.isMetaDown() && (!e.isControlDown() || e.isAltDown());
             }
-        	return !e.isControlDown() && !e.isAltDown() && !e.isMetaDown();
+        	return !e.isControlDown() && !e.isMetaDown();
         };
 
         Predicate<KeyEvent> isChar = e ->


### PR DESCRIPTION
Fixes #967 OSX: Entering curly braces and brackets is broken.

This is likely due to a regression by PR #922. This fix realigns the code to look/behave more like the way it did before.