### PR TITLE
Fix JavaKeywordsDemo comment pattern

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
@@ -49,7 +49,8 @@ public class JavaKeywordsDemo extends Application {
     private static final String BRACKET_PATTERN = "\\[|\\]";
     private static final String SEMICOLON_PATTERN = "\\;";
     private static final String STRING_PATTERN = "\"([^\"\\\\]|\\\\.)*\"";
-    private static final String COMMENT_PATTERN = "//[^\n]*" + "|" + "/\\*(.|\\R)*?\\*/";
+    private static final String COMMENT_PATTERN = "//[^\n]*" + "|" + "/\\*(.|\\R)*?\\*/"   // for whole text processing (text blocks)
+    		                          + "|" + "/\\*[^\\v]*" + "|" + "^\\h*\\*([^\\v]*|/)";  // for visible paragraph processing (line by line)
 
     private static final Pattern PATTERN = Pattern.compile(
             "(?<KEYWORD>" + KEYWORD_PATTERN + ")"

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
@@ -99,6 +99,8 @@ public class JavaKeywordsDemo extends Application {
         codeArea.setContextMenu( new DefaultContextMenu() );
 /*
         // recompute the syntax highlighting for all text, 500 ms after user stops editing area
+        // Note that this shows how it can be done but is not recommended for production with
+        // large files as it does a full scan of ALL the text every time there is a change !
         Subscription cleanupWhenNoLongerNeedIt = codeArea
 
                 // plain changes = ignore style changes that are emitted when syntax highlighting is reapplied
@@ -116,6 +118,8 @@ public class JavaKeywordsDemo extends Application {
         // run: `cleanupWhenNoLongerNeedIt.unsubscribe();`
 */
         // recompute syntax highlighting only for visible paragraph changes
+        // Note that this shows how it can be done but is not recommended for production where multi-
+        // line syntax requirements are needed, like comment blocks without a leading * on each line. 
         codeArea.getVisibleParagraphs().addModificationObserver
         (
             new VisibleParagraphStyler<>( codeArea, this::computeHighlighting )


### PR DESCRIPTION
Fixes #970 

The JavaKeywordsDemo was recently updated with a way to only compute highlighting on the visible paragraphs instead of on the whole contents of the editor. However the regular expression pattern for comments was originally designed to work on a block of text and not lines of text, which is why the multi-line comments aren't being correctly styled (when using the visible paragraphs highlighting method).

This PR updates the COMMENT_PATTERN to address this, although it's not perfect.