### PR TITLE
Add BasicCAT to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Who uses RichTextFX?
 - [Chorus](https://github.com/iAmGio/chorus)
 - [EpubFx](https://gitlab.com/finanzer/epubfx/)
 - [SqlBrowserFx](https://github.com/pariskol/sqlbrowserfx/)
+- [BasicCAT](https://github.com/xulihang/BasicCAT/)
 
 If you use RichTextFX in an interesting project, I would like to know!
 


### PR DESCRIPTION
Hi there,

I used RichTextFX in my project [BasicCAT](https://github.com/xulihang/BasicCAT), which is a computer-aided translaton tool to style tags, whitespaces and furthurmore. I would like to know if it could be included in the section 'Who uses RichTextFX?'.

![image](https://user-images.githubusercontent.com/5462205/99875567-b3ff4900-2c2b-11eb-9653-6478bed5af86.png)

Regards
