### PR TITLE
Fix Ctrl+A and Ctrl+End fold navigation

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1470,6 +1470,10 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     {
         if ( getCell( newParagraph ).isFolded() )
         {
+            // Prevent Ctrl+A and Ctrl+End breaking when the last paragraph is folded
+            // github.com/FXMisc/RichTextFX/pull/965#issuecomment-706268116
+            if ( newParagraph == getParagraphs().size() - 1 ) return;
+
             int skip = (newParagraph - prevParagraph > 0) ? +1 : -1;
             int p = newParagraph + skip;
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -240,7 +240,7 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
 
     public <T extends Node & Caret> double getCaretOffsetX(T caret) {
         layout(); // ensure layout, is a no-op if not dirty
-        checkWithinParagraph(caret);
+        if ( isVisible() /* notFolded */ ) checkWithinParagraph(caret);
         Bounds bounds = caret.getLayoutBounds();
         return (bounds.getMinX() + bounds.getMaxX()) / 2;
     }


### PR DESCRIPTION
Fixes Ctrl+A misbehavior when the last paragraph is folded, as reported in PR comment [here](https://github.com/FXMisc/RichTextFX/pull/965#issuecomment-706268116).