### PR TITLE
Updated visibleParToAllParIndex

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -984,7 +984,14 @@ public class GenericStyledArea<PS, SEG, S> extends Region
                     getVisibleParagraphs().size() - 1, visibleParIndex)
             );
         }
-        return virtualFlow.visibleCells().get( visibleParIndex ).getNode().getIndex();
+
+        Cell<Paragraph<PS,SEG,S>, ParagraphBox<PS,SEG,S>> visibleCell = null;
+
+        if ( visibleParIndex > 0 ) visibleCell = virtualFlow.visibleCells().get( visibleParIndex );
+        else visibleCell = virtualFlow.getCellIfVisible( virtualFlow.getFirstVisibleIndex() )
+            .orElseGet( () -> virtualFlow.visibleCells().get( visibleParIndex ) );
+
+        return visibleCell.getNode().getIndex();
     }
 
     @Override


### PR DESCRIPTION
Fixes #998 where the incorrect first visible paragraph gets returned when navigating backwards through the list.