### PR TITLE
Added foldCheck skipping

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1550,11 +1550,14 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         replace( startPos, endPos, subDoc );
         recreateParagraphGraphic( offsetToPosition( startPos, Bias.Backward ).getMajor() );
         moveTo( startPos );
+        foldCheck = true;
     }
+
+    protected boolean foldCheck = false;
 
     private void skipOverFoldedParagraphs( ObservableValue<? extends Integer> ob, Integer prevParagraph, Integer newParagraph )
     {
-        if ( getCell( newParagraph ).isFolded() )
+        if ( foldCheck && getCell( newParagraph ).isFolded() )
         {
             // Prevent Ctrl+A and Ctrl+End breaking when the last paragraph is folded
             // github.com/FXMisc/RichTextFX/pull/965#issuecomment-706268116

--- a/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-area.css
+++ b/richtextfx/src/main/resources/org/fxmisc/richtext/styled-text-area.css
@@ -16,4 +16,4 @@
 }
 
 /* For folding/hiding paragraphs. It's applied to TextFlow. */
-.collapse { visibility: collapse; }
+.styled-text-area .collapse { visibility: collapse; }


### PR DESCRIPTION
I've experienced CSS errors in production with regards to the new paragraph folding code, even though I don't use folding.

> WARNING: Caught 'java.lang.ClassCastException: class java.lang.String cannot be cast to class javafx.scene.paint.Paint (java.lang.String is in module java.base of loader 'bootstrap'; javafx.scene.paint.Paint is in module javafx.graphics@11.0.6 of loader 'platform')' while converting value for '-fx-background-color' from rule '*.text-area' in stylesheet jrt:/javafx.controls/com/sun/javafx/scene/control/skin/caspian/caspian.bss
Oct 26, 2020 1:40:49 PM javafx.scene.CssStyleHelper calculateValue

I've narrowed down these errors to being triggered by the `skipOverFoldedParagraphs` method, which makes sense because before this PR it was being called whenever the paragraph index changes.

From the exception it's possible that this issue is confined to the Caspian theme only, and may not be triggered by Modena.
Unfortunately I don't know as I've never had this error in development and I don't know under which circumstances this exception occurs in production. So this PR is a safeguard because I haven't been able to determine why the CSS errors occur.
