### PR TITLE
Follow caret regression fix

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1926,7 +1926,17 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     private void followCaret() {
         int parIdx = getCurrentParagraph();
         ParagraphBox<PS, SEG, S> paragrafBox = virtualFlow.getCell( parIdx ).getNode();
-        Bounds caretBounds = paragrafBox.getCaretBounds( caretSelectionBind.getUnderlyingCaret() );
+
+        Bounds caretBounds;
+        try {
+            // This is the default mechanism, but is also needed for https://github.com/FXMisc/RichTextFX/issues/1017
+            caretBounds = paragrafBox.getCaretBounds( caretSelectionBind.getUnderlyingCaret() );
+        }
+        catch ( IllegalArgumentException EX ) {
+            // This is an alternative mechanism, to address https://github.com/FXMisc/RichTextFX/issues/939
+            caretBounds = caretSelectionBind.getUnderlyingCaret().getLayoutBounds();
+        }
+
         double graphicWidth = paragrafBox.getGraphicPrefWidth();
         Bounds region = extendLeft(caretBounds, graphicWidth);
         double scrollX = virtualFlow.getEstimatedScrollX();


### PR DESCRIPTION
It turns out that my fix for #939 causes the caret to not be properly followed in certain cases #1017.

The fix for the latter issue was to revert back to the way the caret bounds was being acquired previously and so undoing the fix for the former problem. This PR basically combines the previous two fixes into one. 

I confess that this is now probably more of a hack, but it does address the problem raised in 939 without breaking anything.

The actual problem seems to be that the new paragraph hasn't received the/a caret at this point. Since this is a corner case and I believe happens infrequently I don't feel it justifies spending a lot of time to find a more elegant/proper solution. Hence this PR ;-)