### PR TITLE
Make CaretNode transparent to mouse picking (fixes #124)

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/CaretNode.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CaretNode.java
@@ -143,6 +143,7 @@ public class CaretNode extends Path implements Caret, Comparable<CaretNode> {
 
         this.getStyleClass().add("caret");
         this.setManaged(false);
+        this.setMouseTransparent(true); // don't want the caret to be pickable, see iss 124
 
         internalTextPosition = Var.newSimpleVar(startingPosition);
         position = internalTextPosition.suspendable();


### PR DESCRIPTION
When you install a mouse handler on a TextExt area using setOnMouseClicked() or similar, there's a small chance that your mouse click will be ignored. This happens approximately one time in ten in my experience.  The problem occurs when you click at the exact same position as the flashing caret while the caret is visible; this confuses the java FX mouse-picking algorithm, which causes the event to be sent to the ParagraphText node rather than the TextExt. The fix is simply to make the caret transparent to mouse picking.

See this link for more evidence + screenshots : https://github.com/FXMisc/RichTextFX/issues/124

(should be a safe change, I can't think of any reason you'd want the caret to be pickable)


