### PR TITLE
Fix for exception: `IllegalArgumentException` - duplicate children added

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -157,7 +157,9 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
                 // see the note at highlightTextFill
                 JavaFXCompatibility.Text_selectionFillProperty(t).bind(t.fillProperty());
             }
-            getChildren().add(n);
+            if (!getChildren().contains(n)) {
+                getChildren().add(n);
+            }
         });
 
         // set up custom css shape helpers


### PR DESCRIPTION
This is fix for exception:
```
Exception in thread "JavaFX Application Thread" java.lang.IllegalArgumentException: Children: duplicate children added: parent = ParagraphText@1755448599(paragraph=Par[; StyledSegment(segment=right(ImageSegment@6c39de9d) style=editor-img), StyledSegment(segment=right(ImageSegment@6c39de9d) style=)])
	at javafx.graphics/javafx.scene.Parent$3.onProposedChange(Parent.java:561)
	at javafx.base/com.sun.javafx.collections.VetoableListDecorator.add(VetoableListDecorator.java:205)
	at org.fxmisc.richtext.ParagraphText.lambda$new$4(ParagraphText.java:160)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.LinkedList$LLSpliterator.forEachRemaining(LinkedList.java:1242)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at org.fxmisc.richtext.ParagraphText.<init>(ParagraphText.java:153)
	at org.fxmisc.richtext.ParagraphBox.<init>(ParagraphBox.java:98)
	at org.fxmisc.richtext.GenericStyledArea.createCell(GenericStyledArea.java:1813)
	at org.fxmisc.richtext.GenericStyledArea.lambda$new$11(GenericStyledArea.java:764)
	at org.fxmisc.flowless.CellPool.getCell(CellPool.java:28)
	at org.fxmisc.flowless.CellListManager.cellForItem(CellListManager.java:90)
	at org.reactfx.collection.MappedList.get(MappedList.java:27)
	at org.reactfx.collection.MemoizationListImpl.get(MemoizationList.java:99)
	at org.fxmisc.flowless.CellListManager.getCell(CellListManager.java:73)
	at org.fxmisc.flowless.CellPositioner.getSizedCell(CellPositioner.java:217)
	at org.fxmisc.flowless.CellPositioner.placeStartAt(CellPositioner.java:127)
	at org.fxmisc.flowless.Navigator.fillForwardFrom0(Navigator.java:280)
	at org.fxmisc.flowless.Navigator.fillForwardFrom(Navigator.java:272)
	at org.fxmisc.flowless.Navigator.fillForwardFrom(Navigator.java:258)
	at org.fxmisc.flowless.Navigator.visit(Navigator.java:159)
	at org.fxmisc.flowless.MinDistanceTo.accept(TargetPosition.java:198)
	at org.fxmisc.flowless.Navigator.layoutChildren(Navigator.java:80)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1207)
	at org.fxmisc.flowless.VirtualFlow.layoutChildren(VirtualFlow.java:257)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1207)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1214)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1214)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1214)
	at javafx.graphics/javafx.scene.Parent.layout(Parent.java:1214)
	at javafx.graphics/javafx.scene.Scene.doLayoutPass(Scene.java:576)
	at javafx.graphics/javafx.scene.Scene$ScenePulseListener.pulse(Scene.java:2476)
	at javafx.graphics/com.sun.javafx.tk.Toolkit.lambda$runPulse$2(Toolkit.java:413)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
	at javafx.graphics/com.sun.javafx.tk.Toolkit.runPulse(Toolkit.java:412)
	at javafx.graphics/com.sun.javafx.tk.Toolkit.firePulse(Toolkit.java:439)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.pulse(QuantumToolkit.java:563)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.pulse(QuantumToolkit.java:543)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.pulseFromQueue(QuantumToolkit.java:536)
	at javafx.graphics/com.sun.javafx.tk.quantum.QuantumToolkit.lambda$runToolkit$11(QuantumToolkit.java:342)
	at javafx.graphics/com.sun.glass.ui.InvokeLaterDispatcher$Future.run$$$capture(InvokeLaterDispatcher.java:96)
	at javafx.graphics/com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java)
	at javafx.graphics/com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at javafx.graphics/com.sun.glass.ui.gtk.GtkApplication.lambda$runLoop$11(GtkApplication.java:277)
	at java.base/java.lang.Thread.run(Thread.java:831)
```

The problem occurred for me when someone in Editor writes very fast near the custom Segment (for example quickly press of many random keys), and applies when the Node in the Segment and Segment is cached:

```java
public class ImageSegment extends BaseSegment {
// ....
    @Override
    public Node createNode(TextStyle textStyle) {
        if (label == null) {
            label = someCreateLogic();
        }
        return label;
    }
// ...
}
```

I'm not sure if caching Segments and Nodes is a good approach here, but there may be e.g. large images that we don't want to reload every time when RichTextFx want to re-create segment (e.g. creating and destroying it because of scrolling).