### PR TITLE
Fix async demo syntax highlighting after file load

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsAsyncDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsAsyncDemo.java
@@ -93,6 +93,7 @@ public class JavaKeywordsAsyncDemo extends Application {
         codeArea.setParagraphGraphicFactory(LineNumberFactory.get(codeArea));
         Subscription cleanupWhenDone = codeArea.multiPlainChanges()
                 .successionEnds(Duration.ofMillis(500))
+                .retainLatestUntilLater(executor)
                 .supplyTask(this::computeHighlightingAsync)
                 .awaitLatest(codeArea.multiPlainChanges())
                 .filterMap(t -> {


### PR DESCRIPTION
Syntax highlighting doesn't immediately work right after loading a new file

Fixes #1044 

Thanks to @sirop