### PR TITLE
Change code area navigation

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
@@ -1,6 +1,5 @@
 package org.fxmisc.richtext;
 
-import java.text.BreakIterator;
 import java.util.Collection;
 
 import javafx.beans.NamedArg;
@@ -51,51 +50,5 @@ public class CodeArea extends StyleClassedTextArea {
 
         // position the caret at the beginning
         selectRange(0, 0);
-    }
-    
-    @Override // to select words containing underscores
-    public void selectWord()
-    {
-        if ( getLength() == 0 ) return;
-
-        CaretSelectionBind<?,?,?> csb = getCaretSelectionBind();
-        int paragraph = csb.getParagraphIndex();
-        int position = csb.getColumnPosition(); 
-        
-        String paragraphText = getText( paragraph );
-        BreakIterator breakIterator = BreakIterator.getWordInstance( getLocale() );
-        breakIterator.setText( paragraphText );
-
-        breakIterator.preceding( position );
-        int start = breakIterator.current();
-        
-        while ( start > 0 && paragraphText.charAt( start-1 ) == '_' )
-        {
-            if ( --start > 0 && ! breakIterator.isBoundary( start-1 ) )
-            {
-                breakIterator.preceding( start );
-                start = breakIterator.current();
-            }
-        }
-        
-        breakIterator.following( position );
-        int end = breakIterator.current();
-        int len = paragraphText.length();
-        
-        while ( end < len && paragraphText.charAt( end ) == '_' )
-        {
-            if ( ++end < len && ! breakIterator.isBoundary( end+1 ) )
-            {
-                breakIterator.following( end );
-                end = breakIterator.current();
-            }
-            // For some reason single digits aren't picked up so ....
-            else if ( Character.isDigit( paragraphText.charAt( end ) ) )
-            {
-                end++;
-            }
-        }
-        
-        csb.selectRange( paragraph, start, paragraph, end );
     }
 }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/CodeArea.java
@@ -1,6 +1,8 @@
 package org.fxmisc.richtext;
 
 import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javafx.beans.NamedArg;
 import org.fxmisc.richtext.model.EditableStyledDocument;
@@ -50,5 +52,82 @@ public class CodeArea extends StyleClassedTextArea {
 
         // position the caret at the beginning
         selectRange(0, 0);
+    }
+
+    protected Pattern WORD_PATTERN = Pattern.compile( "\\w+" );
+    protected Pattern WORD_SPACE = Pattern.compile( "\\w*\\h*" );
+
+    @Override
+    public void wordBreaksBackwards(int n, SelectionPolicy selectionPolicy)
+    {
+        if ( getLength() == 0 ) return;
+
+        CaretSelectionBind<?,?,?> csb = getCaretSelectionBind();
+        int paragraph = csb.getParagraphIndex();
+        int position = csb.getColumnPosition(); 
+        int prevWord = 0;
+
+        if ( position == 0 ) {
+            prevWord = getParagraph( --paragraph ).length();
+            moveTo( paragraph, prevWord, selectionPolicy );
+            return;
+        }
+        
+        Matcher m = WORD_SPACE.matcher( getText( paragraph ) );
+        
+        while ( m.find() )
+        {
+            if ( m.start() == position ) {
+                moveTo( paragraph, prevWord, selectionPolicy );
+                break;
+            }
+            if ( (prevWord = m.end()) >= position ) {
+                moveTo( paragraph, m.start(), selectionPolicy );
+                break;
+            }
+        }
+    }
+    
+    @Override
+    public void wordBreaksForwards(int n, SelectionPolicy selectionPolicy)
+    {
+        if ( getLength() == 0 ) return;
+
+        CaretSelectionBind<?,?,?> csb = getCaretSelectionBind();
+        int paragraph = csb.getParagraphIndex();
+        int position = csb.getColumnPosition(); 
+        
+        Matcher m = WORD_SPACE.matcher( getText( paragraph ) );
+        
+        while ( m.find() )
+        {
+            if ( m.start() > position ) {
+                moveTo( paragraph, m.start(), selectionPolicy );
+                break;
+            }
+            if ( m.hitEnd() ) {
+                moveTo( paragraph+1, 0, selectionPolicy );
+            }
+        }
+    }
+    
+    @Override
+    public void selectWord()
+    {
+        if ( getLength() == 0 ) return;
+
+        CaretSelectionBind<?,?,?> csb = getCaretSelectionBind();
+        int paragraph = csb.getParagraphIndex();
+        int position = csb.getColumnPosition(); 
+        
+        Matcher m = WORD_PATTERN.matcher( getText( paragraph ) );
+
+        while ( m.find() )
+        {
+            if ( m.end() > position ) {
+                csb.selectRange( paragraph, m.start(), paragraph, m.end() );
+                return;
+            }
+        }
     }
 }


### PR DESCRIPTION
Resolves #1087 Double clicking in CodeArea should work as expected
Replaced CodeArea navigation implementation using BreakIterator to use Regex instead.