### PR TITLE
Added null style check

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1535,6 +1535,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
 
     @Override
     public void replace(int start, int end, SEG seg, S style) {
+        if (style == null) style = getTextStyleForInsertionAt(start);
         StyledDocument<PS, SEG, S> doc = ReadOnlyStyledDocument.fromSegment(
                 seg, getParagraphStyleForInsertionAt(start), style, segmentOps
         );


### PR DESCRIPTION
Addresses #1118 

If `append` or `replace` methods are invoked with a **null style** then behave like `replaceText`
