### PR TITLE
Add JVM explorer to README project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Who uses RichTextFX?
 - [JabRef](http://www.jabref.org/)
 - [JDialogue](https://github.com/SkyAphid/JDialogue)
 - [JuliarFuture](https://juliar.org)
+- [JVM Explorer](https://github.com/Naton1/jvm-explorer)
 - [Kappa IDE](https://bitbucket.org/TomasMikula/kappaide/)
 - [KeenWrite](https://github.com/DaveJarvis/keenwrite)
 - [Markdown Writer FX](https://github.com/JFormDesigner/markdown-writer-fx)


### PR DESCRIPTION
Hey all, I use RichTextFX in a project I recently released and would like to list it on the README. It's been a pleasure to work with it so far :)

![image](https://user-images.githubusercontent.com/28943608/179443195-64f42dc0-393b-4165-9a43-4d6683546fa7.png)
