### PR TITLE
Support wavy underlines (issue #1131)

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -213,7 +213,9 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
                     if (attributes.dashArray != null) {
                         underlineShape.getStrokeDashArray().setAll(attributes.dashArray);
                     }
-                    underlineShape.getElements().setAll(getUnderlineShape(tuple._2));
+                    PathElement[] shape = getUnderlineShape(tuple._2.getStart(), tuple._2.getEnd(),
+                                                            attributes.offset, attributes.wave);
+                    underlineShape.getElements().setAll(shape);
                 },
                 addToForeground,
                 clearUnusedShapes
@@ -597,17 +599,24 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
     private static class UnderlineAttributes extends LineAttributesBase {
 
         final StrokeLineCap cap;
+        final double offset;
+        final double wave;
 
         UnderlineAttributes(TextExt text) {
             super(text.getUnderlineColor(), text.getUnderlineWidth(), text.underlineDashArrayProperty());
             cap = text.getUnderlineCap();
+            Number offsetNumber = text.getUnderlineOffset();
+            offset = offsetNumber == null ? 0 : offsetNumber.doubleValue();
+            Number waveNumber = text.getUnderlineWave();
+            wave = waveNumber == null ? 0 : waveNumber.doubleValue();
         }
 
         /**
          * Same as {@link #equals(Object)} but no need to check the object for its class
          */
         public boolean equalsFaster(UnderlineAttributes attr) {
-            return super.equalsFaster(attr) && Objects.equals(cap, attr.cap);
+            return super.equalsFaster(attr) && Objects.equals(cap, attr.cap)
+                   && offset == attr.offset && wave == attr.wave;
         }
 
         @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -214,7 +214,7 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
                         underlineShape.getStrokeDashArray().setAll(attributes.dashArray);
                     }
                     PathElement[] shape = getUnderlineShape(tuple._2.getStart(), tuple._2.getEnd(),
-                                                            attributes.offset, attributes.wave);
+                                                            attributes.offset, attributes.waveRadius);
                     underlineShape.getElements().setAll(shape);
                 },
                 addToForeground,
@@ -600,15 +600,15 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
 
         final StrokeLineCap cap;
         final double offset;
-        final double wave;
+        final double waveRadius;
 
         UnderlineAttributes(TextExt text) {
             super(text.getUnderlineColor(), text.getUnderlineWidth(), text.underlineDashArrayProperty());
             cap = text.getUnderlineCap();
             Number offsetNumber = text.getUnderlineOffset();
             offset = offsetNumber == null ? 0 : offsetNumber.doubleValue();
-            Number waveNumber = text.getUnderlineWave();
-            wave = waveNumber == null ? 0 : waveNumber.doubleValue();
+            Number waveRadiusNumber = text.getUnderlineWaveRadius();
+            waveRadius = waveRadiusNumber == null ? 0 : waveRadiusNumber.doubleValue();
         }
 
         /**
@@ -616,7 +616,7 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
          */
         public boolean equalsFaster(UnderlineAttributes attr) {
             return super.equalsFaster(attr) && Objects.equals(cap, attr.cap)
-                   && offset == attr.offset && wave == attr.wave;
+                   && offset == attr.offset && waveRadius == attr.waveRadius;
         }
 
         @Override

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -605,10 +605,12 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
         UnderlineAttributes(TextExt text) {
             super(text.getUnderlineColor(), text.getUnderlineWidth(), text.underlineDashArrayProperty());
             cap = text.getUnderlineCap();
+            Number waveNumber = text.getUnderlineWaveRadius();
+            waveRadius = waveNumber == null ? 0 : waveNumber.doubleValue();
             Number offsetNumber = text.getUnderlineOffset();
-            offset = offsetNumber == null ? 0 : offsetNumber.doubleValue();
-            Number waveRadiusNumber = text.getUnderlineWaveRadius();
-            waveRadius = waveRadiusNumber == null ? 0 : waveRadiusNumber.doubleValue();
+            offset = offsetNumber == null ? waveRadius * 0.5 : offsetNumber.doubleValue();
+            // The larger the radius the bigger the offset needs to be, so
+            // a reasonable default is provided if no offset is specified.
         }
 
         /**

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextExt.java
@@ -43,7 +43,7 @@ public class TextExt extends Text {
         styleables.add(StyleableProperties.UNDERLINE_COLOR);
         styleables.add(StyleableProperties.UNDERLINE_WIDTH);
         styleables.add(StyleableProperties.UNDERLINE_OFFSET);
-        styleables.add(StyleableProperties.UNDERLINE_WAVE);
+        styleables.add(StyleableProperties.UNDERLINE_WAVE_RADIUS);
         styleables.add(StyleableProperties.UNDERLINE_DASH_ARRAY);
         styleables.add(StyleableProperties.UNDERLINE_CAP);
 
@@ -82,8 +82,8 @@ public class TextExt extends Text {
             null, "underlineOffset", this, StyleableProperties.UNDERLINE_OFFSET
     );
 
-    private final StyleableObjectProperty<Number> underlineWave = new CustomStyleableProperty<>(
-            null, "underlineWave", this, StyleableProperties.UNDERLINE_WAVE
+    private final StyleableObjectProperty<Number> underlineWaveRadius = new CustomStyleableProperty<>(
+            null, "underlineWaveRadius", this, StyleableProperties.UNDERLINE_WAVE_RADIUS
     );
 
     private final StyleableObjectProperty<Number[]> underlineDashArray = new CustomStyleableProperty<>(
@@ -249,21 +249,21 @@ public class TextExt extends Text {
      */
     public ObjectProperty<Number> underlineOffsetProperty() { return underlineOffset; }
 
-    public Number getUnderlineWave() { return underlineWave.get(); }
-    public void setUnderlineWave(Number radius) { underlineWave.set(radius); }
+    public Number getUnderlineWaveRadius() { return underlineWaveRadius.get(); }
+    public void setUnderlineWaveRadius(Number radius) { underlineWaveRadius.set(radius); }
 
     /**
      * The arc radius used to draw a wavy underline.  If null or zero, the
      * underline will be a simple line.
      *
-     * Can be styled from CSS using the "-rtfx-underline-wave" property.
+     * Can be styled from CSS using the "-rtfx-underline-wave-radius" property.
      *
      * <p>Note that the underline properties specified here are orthogonal to the {@link #underlineProperty()} inherited
      * from {@link Text}.  The underline properties defined here in {@link TextExt} will cause an underline to be
      * drawn if {@link #underlineWidthProperty()} is non-null and greater than zero, regardless of
      * the value of {@link #underlineProperty()}.</p>
      */
-    public ObjectProperty<Number> underlineWaveProperty() { return underlineWave; }
+    public ObjectProperty<Number> underlineWaveRadiusProperty() { return underlineWaveRadius; }
 
     // Dash array for the text underline
     public Number[] getUnderlineDashArray() { return underlineDashArray.get(); }
@@ -338,9 +338,9 @@ public class TextExt extends Text {
             0, n -> n.underlineOffset
         );
 
-        private static final CssMetaData<TextExt, Number> UNDERLINE_WAVE = new CustomCssMetaData<>(
-            "-rtfx-underline-wave", StyleConverter.getSizeConverter(),
-            0, n -> n.underlineWave
+        private static final CssMetaData<TextExt, Number> UNDERLINE_WAVE_RADIUS = new CustomCssMetaData<>(
+            "-rtfx-underline-wave-radius", StyleConverter.getSizeConverter(),
+            0, n -> n.underlineWaveRadius
         );
 
         private static final CssMetaData<TextExt, Number[]> UNDERLINE_DASH_ARRAY = new CustomCssMetaData<>(

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextExt.java
@@ -42,6 +42,8 @@ public class TextExt extends Text {
         styleables.add(StyleableProperties.BORDER_DASH_ARRAY);
         styleables.add(StyleableProperties.UNDERLINE_COLOR);
         styleables.add(StyleableProperties.UNDERLINE_WIDTH);
+        styleables.add(StyleableProperties.UNDERLINE_OFFSET);
+        styleables.add(StyleableProperties.UNDERLINE_WAVE);
         styleables.add(StyleableProperties.UNDERLINE_DASH_ARRAY);
         styleables.add(StyleableProperties.UNDERLINE_CAP);
 
@@ -74,6 +76,14 @@ public class TextExt extends Text {
 
     private final StyleableObjectProperty<Number> underlineWidth = new CustomStyleableProperty<>(
             null, "underlineWidth", this, StyleableProperties.UNDERLINE_WIDTH
+    );
+
+    private final StyleableObjectProperty<Number> underlineOffset = new CustomStyleableProperty<>(
+            null, "underlineOffset", this, StyleableProperties.UNDERLINE_OFFSET
+    );
+
+    private final StyleableObjectProperty<Number> underlineWave = new CustomStyleableProperty<>(
+            null, "underlineWave", this, StyleableProperties.UNDERLINE_WAVE
     );
 
     private final StyleableObjectProperty<Number[]> underlineDashArray = new CustomStyleableProperty<>(
@@ -223,6 +233,38 @@ public class TextExt extends Text {
      */
     public ObjectProperty<Number> underlineWidthProperty() { return underlineWidth; }
 
+    public Number getUnderlineOffset() { return underlineOffset.get(); }
+    public void setUnderlineOffset(Number width) { underlineOffset.set(width); }
+
+    /**
+     * The offset of the underline for a section of text.  If null or zero,
+     * the underline will be drawn along the baseline of the text.
+     *
+     * Can be styled from CSS using the "-rtfx-underline-offset" property.
+     *
+     * <p>Note that the underline properties specified here are orthogonal to the {@link #underlineProperty()} inherited
+     * from {@link Text}.  The underline properties defined here in {@link TextExt} will cause an underline to be
+     * drawn if {@link #underlineWidthProperty()} is non-null and greater than zero, regardless of
+     * the value of {@link #underlineProperty()}.</p>
+     */
+    public ObjectProperty<Number> underlineOffsetProperty() { return underlineOffset; }
+
+    public Number getUnderlineWave() { return underlineWave.get(); }
+    public void setUnderlineWave(Number radius) { underlineWave.set(radius); }
+
+    /**
+     * The arc radius used to draw a wavy underline.  If null or zero, the
+     * underline will be a simple line.
+     *
+     * Can be styled from CSS using the "-rtfx-underline-wave" property.
+     *
+     * <p>Note that the underline properties specified here are orthogonal to the {@link #underlineProperty()} inherited
+     * from {@link Text}.  The underline properties defined here in {@link TextExt} will cause an underline to be
+     * drawn if {@link #underlineWidthProperty()} is non-null and greater than zero, regardless of
+     * the value of {@link #underlineProperty()}.</p>
+     */
+    public ObjectProperty<Number> underlineWaveProperty() { return underlineWave; }
+
     // Dash array for the text underline
     public Number[] getUnderlineDashArray() { return underlineDashArray.get(); }
     public void setUnderlineDashArray(Number[] dashArray) { underlineDashArray.set(dashArray); }
@@ -289,6 +331,16 @@ public class TextExt extends Text {
         private static final CssMetaData<TextExt, Number> UNDERLINE_WIDTH = new CustomCssMetaData<>(
                 "-rtfx-underline-width", StyleConverter.getSizeConverter(),
                 0, n -> n.underlineWidth
+        );
+
+        private static final CssMetaData<TextExt, Number> UNDERLINE_OFFSET = new CustomCssMetaData<>(
+            "-rtfx-underline-offset", StyleConverter.getSizeConverter(),
+            0, n -> n.underlineOffset
+        );
+
+        private static final CssMetaData<TextExt, Number> UNDERLINE_WAVE = new CustomCssMetaData<>(
+            "-rtfx-underline-wave", StyleConverter.getSizeConverter(),
+            0, n -> n.underlineWave
         );
 
         private static final CssMetaData<TextExt, Number[]> UNDERLINE_DASH_ARRAY = new CustomCssMetaData<>(

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
@@ -106,11 +106,11 @@ class TextFlowExt extends TextFlow {
      * @param from The index of the first character.
      * @param to The index of the last character.
      * @param offset Ignored (only implemented for Java 9+)
-     * @param wave Ignored (only implemented for Java 9+)
+     * @param waveRadius Ignored (only implemented for Java 9+)
      * @return An array with the PathElement objects which define an
      *         underline from the first to the last character.
      */
-    PathElement[] getUnderlineShape(int from, int to, double offset, double wave) {
+    PathElement[] getUnderlineShape(int from, int to, double offset, double waveRadius) {
         // get a Path for the text underline
         PathElement[] shape = textLayout().getRange(from, to, TextLayout.TYPE_UNDERLINE, 0, 0);
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
@@ -98,13 +98,19 @@ class TextFlowExt extends TextFlow {
         return getUnderlineShape(range.getStart(), range.getEnd());
     }
 
+    PathElement[] getUnderlineShape(int from, int to) {
+        return getUnderlineShape(from, to, 0, 0);
+    }
+
     /**
      * @param from The index of the first character.
      * @param to The index of the last character.
+     * @param offset Ignored (only implemented for Java 9+)
+     * @param wave Ignored (only implemented for Java 9+)
      * @return An array with the PathElement objects which define an
      *         underline from the first to the last character.
      */
-    PathElement[] getUnderlineShape(int from, int to) {
+    PathElement[] getUnderlineShape(int from, int to, double offset, double wave) {
         // get a Path for the text underline
         PathElement[] shape = textLayout().getRange(from, to, TextLayout.TYPE_UNDERLINE, 0, 0);
 

--- a/richtextfx/src/main/java9/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java9/org/fxmisc/richtext/TextFlowExt.java
@@ -76,11 +76,11 @@ class TextFlowExt extends TextFlow {
      * @param from The index of the first character.
      * @param to The index of the last character.
      * @param offset The distance below the baseline to draw the underline.
-     * @param wave If non-zero, draw a wavy underline with arcs of this radius.
+     * @param waveRadius If non-zero, draw a wavy underline with arcs of this radius.
      * @return An array with the PathElement objects which define an
      *         underline from the first to the last character.
      */
-    PathElement[] getUnderlineShape(int from, int to, double offset, double wave) {
+    PathElement[] getUnderlineShape(int from, int to, double offset, double waveRadius) {
         // get a Path for the text underline
         List<PathElement> result = new ArrayList<>();
         
@@ -95,7 +95,7 @@ class TextFlowExt extends TextFlow {
             LineTo br = (LineTo) shape[ele];
             double y = br.getY() + offset - 2.5;
 
-            if (wave <= 0) {
+            if (waveRadius <= 0) {
                 result.add(new MoveTo(bl.getX(), y));
                 result.add(new LineTo(br.getX(), y));
             }
@@ -109,15 +109,15 @@ class TextFlowExt extends TextFlow {
                 result.add(new MoveTo(x, y));
                 boolean sweep = true;
                 while (x < rx) {
-                    x += wave * 2;
+                    x += waveRadius * 2;
                     if (x > rx) {
                         // Compute the value of y at which the arc intersects
                         // the line x = rx.
-                        double dy = wave * Math.sin(Math.acos((wave - x + rx) / wave));
+                        double dy = waveRadius * Math.sin(Math.acos((waveRadius - x + rx) / waveRadius));
                         if (sweep) y -= dy; else y += dy;
                         x = rx;
                     }
-                    result.add(new ArcTo(wave, wave, 0.0, x, y, false, sweep));
+                    result.add(new ArcTo(waveRadius, waveRadius, 0.0, x, y, false, sweep));
                     sweep = !sweep;
                 }
             }

--- a/richtextfx/src/main/java9/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java9/org/fxmisc/richtext/TextFlowExt.java
@@ -13,8 +13,7 @@ import org.fxmisc.richtext.model.TwoLevelNavigator;
 import javafx.scene.shape.PathElement;
 import javafx.scene.text.HitInfo;
 import javafx.scene.text.TextFlow;
-import javafx.scene.shape.LineTo;
-import javafx.scene.shape.MoveTo;
+import javafx.scene.shape.*;
 
 /**
  * Adds additional API to {@link TextFlow}.


### PR DESCRIPTION
Basic implementation of wavy underlines as described in #1131.

Adds two properties -- "wave" to control the radius of arc used to draw wavy lines, and "offset" to adjust the distance between text and underline, since it can be necessary to increase this for legibility when a wavy underline is in use.  Probably better names are possible.

These are used in `TextFlowExt#getUnderlineShape` to modify the shape produced.  If no radius is specified then a line is drawn as previously; otherwise a series of arcs is drawn, which replicates the appearance of the wavy underlines in common programs such as Microsoft Word.

I have only implemented the wavy-line shape in the Java 9+ version of the class because I can see there's an open question whether it's even worth supporting Java 8 any more (and my opinion FWIW is "no").

I haven't added any tests – if they're required then I would appreciate advice on how to test a purely visual change like this.