### PR TITLE
Add Recaf to 'Who uses RichTextFX'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Who uses RichTextFX?
 - [mqtt-spy](http://kamilfb.github.io/mqtt-spy/)
 - [Nearde IDE](https://github.com/VenityStudio/Nearde-IDE)
 - [OmniEditor](https://github.com/giancosta86/OmniEditor)
+- [Recaf](https://github.com/Col-E/Recaf)
 - [SqlBrowserFx](https://github.com/pariskol/sqlbrowserfx/)
 - [Squirrel SQL client](http://www.squirrelsql.org/)
 - [Xanthic](https://github.com/jrguenther/Xanthic)


### PR DESCRIPTION
Been using RichTextFX for a little over 4 years now, [been quite happy with it](https://github.com/Col-E/Recaf).

![image](https://user-images.githubusercontent.com/21371686/200533156-0162b74a-ff6e-4c41-863f-67f27111fc11.png)

