### PR TITLE
Add to "Who uses RichTextFX?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Who uses RichTextFX?
 - [EpubFx](https://gitlab.com/finanzer/epubfx/)
 - [Everest REST client](https://github.com/RohitAwate/Everest)
 - [JabRef](http://www.jabref.org/)
+- [JfxIDE](https://github.com/Zev-G/JfxIDE)
+- [JFXDevTools](https://github.com/Zev-G/JFXDevTools)
 - [JDialogue](https://github.com/SkyAphid/JDialogue)
 - [JuliarFuture](https://juliar.org)
 - [JVM Explorer](https://github.com/Naton1/jvm-explorer)


### PR DESCRIPTION
Both my [JFXDevTools](https://github.com/Zev-G/JFXDevTools) and [JfxIDE](https://github.com/Zev-G/JfxIDE) have been using RichTextFX and the experience has been super!

JFXIde:
![image](https://user-images.githubusercontent.com/59103153/210187232-807aef51-6102-40ca-ad4c-69d799d77e1a.png)

JFXPlus:
![image](https://user-images.githubusercontent.com/59103153/210187208-93b999ac-0f8d-4c8b-9caf-0551a6fc2d26.png)
![image](https://user-images.githubusercontent.com/59103153/210187212-eb3e9a7d-458e-4c0e-a045-9fd524540a8e.png)
