### PR TITLE
Set TextFlow prefWidth to max for no wrapping

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -74,6 +74,9 @@ class ParagraphBox<PS, SEG, S> extends Region {
 
     private final BooleanProperty wrapText = new SimpleBooleanProperty(false);
     public BooleanProperty wrapTextProperty() { return wrapText; }
+    {
+        wrapText.addListener((obs, old, w) -> requestLayout());
+    }
 
     private final Val<Boolean> isFolded;
     public boolean isFolded() { return isFolded.getValue(); }
@@ -95,13 +98,6 @@ class ParagraphBox<PS, SEG, S> extends Region {
         this.text = new ParagraphText<>(par, nodeFactory);
         applyParagraphStyle.accept(this.text, par.getParagraphStyle());
         isFolded = Val.wrap( text.visibleProperty().not() );
-
-        this.text.setPrefWidth( Double.MAX_VALUE ); // Default for no wrapping
-        wrapText.addListener( (obs, old, wrap) ->
-        {
-            text.setPrefWidth( wrap ? USE_COMPUTED_SIZE : Double.MAX_VALUE );
-            requestLayout();
-        });
         
         // start at -1 so that the first time it is displayed, the caret at pos 0 is not
         // accidentally removed from its parent and moved to this node's ParagraphText

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -240,6 +240,7 @@ class ParagraphBox<PS, SEG, S> extends Region {
     @Override
     protected double computePrefHeight(double width) {
         if ( isFolded.getValue() ) return 0.0;
+        if ( ! wrapText.get() ) width = Double.MAX_VALUE;
         Insets insets = getInsets();
         double overhead = getGraphicPrefWidth() + insets.getLeft() + insets.getRight();
         return text.prefHeight(width - overhead) + insets.getTop() + insets.getBottom() + text.getLineSpacing();
@@ -248,12 +249,17 @@ class ParagraphBox<PS, SEG, S> extends Region {
     @Override
     protected void layoutChildren() {
         Insets ins = getInsets();
-        double w = getWidth() - ins.getLeft() - ins.getRight();
         double h = getHeight() - ins.getTop() - ins.getBottom();
         double graphicWidth = getGraphicPrefWidth();
-        double half = text.getLineSpacing() / 2.0;
 
-        text.resizeRelocate(graphicWidth + ins.getLeft(), ins.getTop() + half, w - graphicWidth, h - half);
+        if ( wrapText.get() ) {
+            double half = text.getLineSpacing() / 2.0;
+            double w = getWidth() - ins.getLeft() - ins.getRight();
+            text.resizeRelocate(graphicWidth + ins.getLeft(), ins.getTop() + half, w - graphicWidth, h - half);
+        } else {
+            text.relocate( graphicWidth + ins.getLeft(), ins.getTop() );
+            text.autosize();
+        }
 
         graphic.filter( Node::isManaged ).ifPresent(
             g -> g.resizeRelocate(graphicOffset.get() + ins.getLeft(), ins.getTop(), graphicWidth, h)

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphBox.java
@@ -74,9 +74,6 @@ class ParagraphBox<PS, SEG, S> extends Region {
 
     private final BooleanProperty wrapText = new SimpleBooleanProperty(false);
     public BooleanProperty wrapTextProperty() { return wrapText; }
-    {
-        wrapText.addListener((obs, old, w) -> requestLayout());
-    }
 
     private final Val<Boolean> isFolded;
     public boolean isFolded() { return isFolded.getValue(); }
@@ -98,6 +95,13 @@ class ParagraphBox<PS, SEG, S> extends Region {
         this.text = new ParagraphText<>(par, nodeFactory);
         applyParagraphStyle.accept(this.text, par.getParagraphStyle());
         isFolded = Val.wrap( text.visibleProperty().not() );
+
+        this.text.setPrefWidth( Double.MAX_VALUE ); // Default for no wrapping
+        wrapText.addListener( (obs, old, wrap) ->
+        {
+            text.setPrefWidth( wrap ? USE_COMPUTED_SIZE : Double.MAX_VALUE );
+            requestLayout();
+        });
         
         // start at -1 so that the first time it is displayed, the caret at pos 0 is not
         // accidentally removed from its parent and moved to this node's ParagraphText


### PR DESCRIPTION
Fixes #1168 wrapTextProperty() is temporarily ignored when inserting characters on a long line