### PR TITLE
Fixed placeholder position in some layouts

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -1775,7 +1775,7 @@ public class GenericStyledArea<PS, SEG, S> extends Region
             if (holder.isResizable()) holder.autosize();
             if (positionPlaceholder) Region.positionInArea
             (
-                holder, getLayoutX(), getLayoutY(), getWidth(), getHeight(), getBaselineOffset(),
+                holder, 0, 0, getWidth(), getHeight(), getBaselineOffset(),
                 ins, placeHolderPos.getHpos(), placeHolderPos.getVpos(), isSnapToPixel()
             );
         }


### PR DESCRIPTION
Fixes #1192, where if an area is NOT the first Node in a layout (e.g. its the second item in a HBox) then the placeholder position was being incorrectly calculated.