### PR TITLE
Added getStyleRange to StyleSpans

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/StyleSpan.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/StyleSpan.java
@@ -11,6 +11,7 @@ public class StyleSpan<S> {
 
     private final S style;
     private final int length;
+    private int startPos = 0;
 
     /**
      * Creates a style span. Note: length cannot be negative.
@@ -24,12 +25,26 @@ public class StyleSpan<S> {
         this.length = length;
     }
 
+    StyleSpan(S style, int start, int length) {
+        this.style = style;
+        this.startPos = start;
+        this.length = length;
+    }
+
     public S getStyle() {
         return style;
     }
 
     public int getLength() {
         return length;
+    }
+
+    void setStart( int start ) {
+        startPos = start;
+    }
+
+    int getStart() {
+        return startPos;
     }
 
     /**
@@ -51,7 +66,7 @@ public class StyleSpan<S> {
     public int hashCode() {
         return Objects.hash(style, length);
     }
-    
+
     @Override
     public String toString() {
         return String.format("StyleSpan[length=%s, style=%s]", length, style);

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/StyleSpans.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/StyleSpans.java
@@ -1,6 +1,7 @@
 package org.fxmisc.richtext.model;
 
-import static org.fxmisc.richtext.model.TwoDimensional.Bias.*;
+import static org.fxmisc.richtext.model.TwoDimensional.Bias.Backward;
+import static org.fxmisc.richtext.model.TwoDimensional.Bias.Forward;
 
 import java.util.Iterator;
 import java.util.Objects;
@@ -10,6 +11,8 @@ import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import javafx.scene.control.IndexRange;
 
 /**
  * Essentially, a list of {@link StyleSpan} objects.
@@ -35,6 +38,12 @@ public interface StyleSpans<S> extends Iterable<StyleSpan<S>>, TwoDimensional {
     int length();
     int getSpanCount();
     StyleSpan<S> getStyleSpan(int index);
+
+    /**
+     * @param position is relative to start of style spans
+     * @return IndexRange relative to start of style spans
+     */
+    IndexRange getStyleRange( int position );
 
     /**
      * Two {@code StyleSpans} objects are considered equal if they contain equal

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/StyleSpansBuilder.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/StyleSpansBuilder.java
@@ -7,6 +7,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import javafx.scene.control.IndexRange;
+
 /**
  * A one-time-use builder that Builds a memory efficient {@link StyleSpans} object.
  *
@@ -169,8 +171,9 @@ public class StyleSpansBuilder<S> {
             } else {
                 StyleSpan<S> prev = spans.get(spans.size() - 1);
                 if(prev.getStyle().equals(span.getStyle())) {
-                    spans.set(spans.size() - 1, new StyleSpan<>(span.getStyle(), prev.getLength() + span.getLength()));
+                    spans.set(spans.size() - 1, new StyleSpan<>(span.getStyle(), prev.getStart(), prev.getLength() + span.getLength()));
                 } else {
+                    span.setStart(prev.getStart() + prev.getLength());
                     spans.add(span);
                 }
             }
@@ -200,6 +203,14 @@ abstract class StyleSpansBase<S> implements StyleSpans<S> {
     @Override
     public Position offsetToPosition(int offset, Bias bias) {
         return navigator.offsetToPosition(offset, bias);
+    }
+
+    @Override
+    public IndexRange getStyleRange(int position) {
+        Position offset = offsetToPosition(position, Bias.Backward);
+        StyleSpan<S> span = getStyleSpan(offset.getMajor());
+        int spanStart = span.getStart();
+        return new IndexRange(spanStart, spanStart + span.getLength());
     }
 
     @Override

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.*;
 import java.util.Collection;
 import java.util.Collections;
 
+import javafx.scene.control.IndexRange;
+
 import org.junit.Test;
 
 public class ParagraphTest {
@@ -55,6 +57,7 @@ public class ParagraphTest {
 			@Override public Position position( int major, int minor ) { return null; }
 			@Override public Position offsetToPosition( int offset, Bias bias ) { return null; }
 			@Override public StyleSpan<Collection<String>> getStyleSpan( int index ) { return null; }
+			@Override public IndexRange getStyleRange(int position) { return null; }
 			@Override public int getSpanCount() { return 0; }
 			@Override public int length() { return 0; }
 		};


### PR DESCRIPTION
Resolves #1231 How to get real size of one span at position X

With this PR a developer can now get the range of a style that crosses paragraphs.
Both the requested position and the returned _IndexRange_ are relative to the start of the requested _StyleSpans_.

Usage Example:
```java
var ss = codeArea.getStyleSpans( 0, codeArea.getLength() );  // From beginning to end
var range = ss.getStyleRange( position );  // So range is from beginning
```