### PR TITLE
Add PMD designer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Who uses RichTextFX?
 - [mqtt-spy](http://kamilfb.github.io/mqtt-spy/)
 - [Nearde IDE](https://github.com/VenityStudio/Nearde-IDE)
 - [OmniEditor](https://github.com/giancosta86/OmniEditor)
+- [PMD Designer](https://github.com/pmd/pmd-designer/)
 - [Recaf](https://github.com/Col-E/Recaf)
 - [SqlBrowserFx](https://github.com/pariskol/sqlbrowserfx/)
 - [Squirrel SQL client](http://www.squirrelsql.org/)


### PR DESCRIPTION
The [PMD designer](https://github.com/pmd/pmd-designer/) is part of the [PMD](https://github.com/pmd/pmd) project, which has more than 4K stars. It uses RichTextFX since a rewrite from scratch in 2017. We built some advanced features on top of RichTextFX, like layered highlighting and AST selection modes. We also use a lot the ReactFX library and programming model. I'm very grateful for these projects :)

![demo](https://docs.pmd-code.org/latest/images/designer/hover-selection.gif)