### PR TITLE
Align TextFlowExt with future getLayoutInfo

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
@@ -1,15 +1,12 @@
 package org.fxmisc.richtext;
 
-import static org.fxmisc.richtext.model.TwoDimensional.Bias.*;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.control.IndexRange;
-import org.fxmisc.richtext.model.TwoLevelNavigator;
-
 import javafx.scene.shape.PathElement;
 import javafx.scene.text.HitInfo;
 import javafx.scene.text.TextFlow;
@@ -19,9 +16,14 @@ import javafx.scene.shape.*;
  * Adds additional API to {@link TextFlow}.
  */
 class TextFlowExt extends TextFlow {
-    
+
     private TextFlowLayout layout;
-    
+    /*
+     * Rename to getLayoutInfo() and delete once JavaFX
+     * [PR1596](https://github.com/openjdk/jfx/pull/1596)
+     * is integrated and released. Also delete 
+     * TextFlowLayout and TextFlowSpan.
+     */
     private TextFlowLayout textLayout()
     {
         if ( layout == null ) {
@@ -31,25 +33,22 @@ class TextFlowExt extends TextFlow {
     }
 
     int getLineCount() {
-        return textLayout().getLineCount();
+        return textLayout().getTextLineCount();
     }
 
     int getLineStartPosition(int charIdx) {
-        TwoLevelNavigator navigator = textLayout().getTwoLevelNavigator();
-        int currentLineIndex = navigator.offsetToPosition(charIdx, Forward).getMajor();
-        return navigator.position(currentLineIndex, 0).toOffset();
+        return textLayout().getTextLineStart( getLineOfCharacter(charIdx) );
     }
 
     int getLineEndPosition(int charIdx) {
-        TwoLevelNavigator navigator = textLayout().getTwoLevelNavigator();
-        int currentLineIndex = navigator.offsetToPosition(charIdx, Forward).getMajor() + 1;
-        int minor = (currentLineIndex == getLineCount()) ? 0 : -1;
-        return navigator.position(currentLineIndex, minor).toOffset();
+        return textLayout().getTextLineEnd( getLineOfCharacter(charIdx) );
     }
 
     int getLineOfCharacter(int charIdx) {
-        TwoLevelNavigator navigator = textLayout().getTwoLevelNavigator();
-        return navigator.offsetToPosition(charIdx, Forward).getMajor();
+        var layout = textLayout();
+        return IntStream.range( 0, getLineCount() )
+                .filter( l -> charIdx <= layout.getTextLineEnd( l ) )
+                .findFirst().orElse( Math.max(0,getLineCount()-1) );
     }
 
     PathElement[] getCaretShape(int charIdx, boolean isLeading) {
@@ -83,9 +82,9 @@ class TextFlowExt extends TextFlow {
     PathElement[] getUnderlineShape(int from, int to, double offset, double waveRadius) {
         // get a Path for the text underline
         List<PathElement> result = new ArrayList<>();
-        
+
         PathElement[] shape = rangeShape( from, to );
-        // The shape is a closed Path for one or more rectangles AROUND the selected text. 
+        // The shape is a closed Path for one or more rectangles AROUND the selected text.
         // shape: [MoveTo origin, LineTo top R, LineTo bottom R, LineTo bottom L, LineTo origin, *]
 
         // Extract the bottom left and right coordinates for each rectangle to get the underline path.
@@ -136,25 +135,34 @@ class TextFlowExt extends TextFlow {
     }
 
     CharacterHit hitLine(double x, int lineIndex) {
-        return hit(x, textLayout().getLineCenter( lineIndex ));
+        Rectangle2D r = textLayout().getLineBounds( lineIndex );
+        double y = r.getMinY() + r.getHeight() / 2.0;
+        return hit( x, y, lineIndex );
     }
 
     CharacterHit hit(double x, double y) {
-        TextFlowSpan span = textLayout().getLineSpan( (float) y );
-        Rectangle2D lineBounds = span.getBounds();
-        
+        var layout = textLayout();
+        int line = IntStream.range( 0, getLineCount() )
+                    .filter( l -> y < layout.getLineBounds( l ).getMaxY() )
+                    .findFirst().orElse( Math.max(0,getLineCount()-1) );
+        return hit( x, y, line );
+    }
+
+    CharacterHit hit(double x, double y, int line) {
+
+        Rectangle2D lineBounds = textLayout().getLineBounds( line );
         HitInfo hit = hitTest(new Point2D(x, y));
         int charIdx = hit.getCharIndex();
         boolean leading = hit.isLeading();
 
-        if (y >= span.getBounds().getMaxY()) {
+        if (y >= lineBounds.getMaxY()) {
             return CharacterHit.insertionAt(charIdx);
         }
 
         if ( ! leading && getLineCount() > 1) {
             // If this is a wrapped paragraph and hit character is at end of hit line, make sure that the
             // "character hit" stays at the end of the hit line (and not at the beginning of the next line).
-            leading = (getLineOfCharacter(charIdx) + 1 < getLineCount() && charIdx + 1 >= span.getStart() + span.getLength());
+            leading = (getLineOfCharacter(charIdx) + 1 < getLineCount() && charIdx + 1 >= textLayout().getTextLineEnd( line ));
         }
 
         if(x < lineBounds.getMinX() || x > lineBounds.getMaxX()) {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowLayout.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowLayout.java
@@ -8,6 +8,7 @@ import org.fxmisc.richtext.model.TwoLevelNavigator;
 import javafx.beans.Observable;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
@@ -34,41 +35,61 @@ class TextFlowLayout
     }
 
 
+    @Deprecated
     float getLineCenter( int lineNo ) {
-        return getLineCount() > 0 ? lineMetrics.get( lineNo ).getCenterY() : 1.0f;
+        return getTextLineCount() > 0 ? lineMetrics.get( lineNo ).getCenterY() : 1.0f;
     }
 
 
+    @Deprecated
     int getLineLength( int lineNo ) {
         return getLineSpan( lineNo ).getLength();
     }
 
 
     TextFlowSpan getLineSpan( int lineNo ) {
-        return getLineCount() > 0 ? lineMetrics.get( lineNo ) : EMPTY_SPAN;
+        return getTextLineCount() > 0 ? lineMetrics.get( lineNo ) : EMPTY_SPAN;
     }
 
 
+    @Deprecated
     TextFlowSpan getLineSpan( float y ) {
-        final int lastLine = getLineCount();
+        final int lastLine = getTextLineCount();
         if ( lastLine < 1 ) return EMPTY_SPAN;
         return lineMetrics.stream().filter( tfs -> y < tfs.getBounds().getMaxY() )
                 .findFirst().orElse( lineMetrics.get( Math.max(0,lastLine-1) ) );
     }
 
 
+    @Deprecated
     TwoLevelNavigator getTwoLevelNavigator() {
-        return new TwoLevelNavigator( this::getLineCount, this::getLineLength );
+        return new TwoLevelNavigator( this::getTextLineCount, this::getLineLength );
     }
-    
+
+
+    Rectangle2D getLineBounds( int line ) {
+        return getLineSpan( line ).getBounds();
+    }
+
+    int getTextLineStart( int line ) {
+        return getLineSpan( line ).getStart();
+    }
+
+    int getTextLineEnd( int line ) {
+        TextFlowSpan span = getLineSpan( line );
+        int end = span.getStart() + span.getLength();
+        if ( line < (getTextLineCount() - 1) ) end--;
+        return end;
+    }
+
 
     /*
      * Iterate through the nodes in the TextFlow to determine the number of lines of text.
      * Also calculates the following metrics for each line along the way: line height,
      * line width, centerY, length (character count), start (character offset from 1st line)
      */
-    int getLineCount() {
-       
+    int getTextLineCount() {
+
         if ( lineCount > -1 ) return lineCount;
 
         lineCount = 0;
@@ -77,7 +98,7 @@ class TextFlowLayout
         int totCharSoFar = 0;
 
         for ( Node n : flow.getChildrenUnmodifiable() ) if ( n.isManaged() ) {
-           
+
             Bounds nodeBounds = n.getBoundsInParent();
             int length = (n instanceof Text) ? ((Text) n).getText().length() : 1;
             PathElement[] shape = flow.rangeShape( totCharSoFar, totCharSoFar+length );
@@ -88,12 +109,12 @@ class TextFlowLayout
                 if ( totLines > 0.0 ) lines--;
                 totLines += lines;
             }
-            else if ( nodeMinY >= prevMaxY ) {                                // Node is on next line 
+            else if ( nodeMinY >= prevMaxY ) {                                // Node is on next line
                 totLines++;
             }
 
             if ( lineMetrics.size() < totLines ) {                            // Add additional lines
-               
+
                 if ( shape.length == 0 ) {
                    lineMetrics.add( new TextFlowSpan( totCharSoFar, length, nodeMinY, nodeBounds.getWidth(), nodeBounds.getHeight() ) );
                     totCharSoFar += length;
@@ -121,14 +142,14 @@ class TextFlowLayout
                 }
             }
             else {
-                // Adjust current line metrics with additional Text or Node embedded in this line 
+                // Adjust current line metrics with additional Text or Node embedded in this line
                 adjustLineMetrics( length, nodeBounds.getWidth(), nodeBounds.getHeight() );
                 totCharSoFar += length;
             }
 
             prevMaxY = Math.max( prevMaxY, nodeBounds.getMaxY() );
         }
-        
+
         lineCount = (int) totLines;
         if ( lineCount > 0 ) return lineCount;
         lineCount = -1;


### PR DESCRIPTION
Refactored `TextFlowExt` to prepare for future API proposed by JavaFX PR openjdk/jfx#1596
by renaming and adding methods in `TextFlowLayout` to match those proposed for `LayoutInfo`.

When the proposed API is integrated and available in JavaFX GA the following steps can be taken:
1. Rename/refactor the `TextFlowExt.textLayout()` method to `getLayoutInfo()`
2. Then delete the `TextFlowExt.getLayoutInfo()` method and reference field.
3. Delete `TextFlowLayout` and `TextFlowSpan`.

Special thanks to @andy-goryachev-oracle