### PR TITLE
Fixed double underline when gap is zero

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -620,7 +620,10 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
 
             Number doubleGapNumber = text.getUnderlineDoubleGap();
             if (doubleGapNumber == null) doubleGap = 0;
-            else doubleGap = doubleGapNumber.doubleValue() + width;
+            else if (doubleGapNumber.doubleValue() > 0.0) {
+            	doubleGap = doubleGapNumber.doubleValue() + width;
+            }
+            else doubleGap = doubleGapNumber.doubleValue();
         }
 
         /**


### PR DESCRIPTION
Fixes #1257  area.getStylesheets().clear() adds 1px to underline width.