### PR TITLE
Added getVisibleParagraphIndexes method

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
@@ -3,10 +3,12 @@ package org.fxmisc.richtext.demo;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -27,6 +29,7 @@ import org.fxmisc.richtext.model.StyleSpans;
 import org.fxmisc.richtext.model.StyleSpansBuilder;
 import org.reactfx.collection.ListModification;
 import org.reactfx.Subscription;
+import org.reactfx.util.Tuple2;
 
 public class JavaKeywordsDemo extends Application {
 
@@ -120,7 +123,7 @@ public class JavaKeywordsDemo extends Application {
         // recompute syntax highlighting only for visible paragraph changes
         // Note that this shows how it can be done but is not recommended for production where multi-
         // line syntax requirements are needed, like comment blocks without a leading * on each line. 
-        codeArea.getVisibleParagraphs().addModificationObserver
+        codeArea.getVisibleParagraphIndexes().addModificationObserver
         (
             new VisibleParagraphStyler<>( codeArea, this::computeHighlighting )
         );
@@ -170,11 +173,10 @@ public class JavaKeywordsDemo extends Application {
         return spansBuilder.create();
     }
 
-    private class VisibleParagraphStyler<PS, SEG, S> implements Consumer<ListModification<? extends Paragraph<PS, SEG, S>>>
+    private class VisibleParagraphStyler<PS, SEG, S> implements Consumer<ListModification<? extends Tuple2<Integer,Paragraph<PS, SEG, S>>>>
     {
         private final GenericStyledArea<PS, SEG, S> area;
         private final Function<String,StyleSpans<S>> computeStyles;
-        private int prevParagraph, prevTextLength;
 
         public VisibleParagraphStyler( GenericStyledArea<PS, SEG, S> area, Function<String,StyleSpans<S>> computeStyles )
         {
@@ -183,24 +185,15 @@ public class JavaKeywordsDemo extends Application {
         }
 
         @Override
-        public void accept( ListModification<? extends Paragraph<PS, SEG, S>> lm )
+        public void accept( ListModification<? extends Tuple2<Integer,Paragraph<PS, SEG, S>>> lm )
         {
-            if ( lm.getAddedSize() > 0 ) Platform.runLater( () ->
-            {
-                int paragraph = Math.min( area.firstVisibleParToAllParIndex() + lm.getFrom(), area.getParagraphs().size()-1 );
-                String text = area.getText( paragraph, 0, paragraph, area.getParagraphLength( paragraph ) );
+            if ( lm.getAddedSize() == 0 ) return;
 
-                if ( paragraph != prevParagraph || text.length() != prevTextLength )
-                {
-                    if ( paragraph < area.getParagraphs().size()-1 )
-                    {
-                        int startPos = area.getAbsolutePosition( paragraph, 0 );
-                        area.setStyleSpans( startPos, computeStyles.apply( text ) );
-                    }
-                    prevTextLength = text.length();
-                    prevParagraph = paragraph;
-                }
-            });
+            List<? extends Tuple2<Integer,Paragraph<PS, SEG, S>>> addList = lm.getAddedSubList();
+            String text = addList.stream().map( t2 -> t2.get2().getText() ).collect( Collectors.joining( "\n" ) );
+            int startPos = area.getAbsolutePosition( addList.get(0).get1(), 0 );
+
+            Platform.runLater( () -> area.setStyleSpans( startPos, computeStyles.apply( text ) ) );
         }
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/GenericStyledArea.java
@@ -94,6 +94,7 @@ import org.reactfx.SuspendableNo;
 import org.reactfx.collection.LiveList;
 import org.reactfx.collection.SuspendableList;
 import org.reactfx.util.Tuple2;
+import org.reactfx.util.Tuples;
 import org.reactfx.value.Val;
 import org.reactfx.value.Var;
 
@@ -569,6 +570,9 @@ public class GenericStyledArea<PS, SEG, S> extends Region
     // paragraphs
     @Override public LiveList<Paragraph<PS, SEG, S>> getParagraphs() { return content.getParagraphs(); }
 
+    private final SuspendableList<Tuple2<Integer,Paragraph<PS, SEG, S>>> visibleParagraphIndexes;
+    public final LiveList<Tuple2<Integer,Paragraph<PS, SEG, S>>> getVisibleParagraphIndexes() { return visibleParagraphIndexes; }
+
     private final SuspendableList<Paragraph<PS, SEG, S>> visibleParagraphs;
     @Override public final LiveList<Paragraph<PS, SEG, S>> getVisibleParagraphs() { return visibleParagraphs; }
 
@@ -816,7 +820,9 @@ public class GenericStyledArea<PS, SEG, S> extends Region
         caretSet.add(caretSelectionBind.getUnderlyingCaret());
         selectionSet.add(caretSelectionBind.getUnderlyingSelection());
 
-        visibleParagraphs = LiveList.map(virtualFlow.visibleCells(), c -> c.getNode().getParagraph()).suspendable();
+        LiveList<ParagraphBox<PS,SEG,S>> visibleNodes = LiveList.map(virtualFlow.visibleCells(), c -> c.getNode());
+        visibleParagraphIndexes = visibleNodes.map(pb -> Tuples.t(pb.getIndex(), pb.getParagraph())).suspendable();
+        visibleParagraphs = visibleNodes.map(pb -> pb.getParagraph()).suspendable();
 
         final Suspendable omniSuspendable = Suspendable.combine(
                 beingUpdated, // must be first, to be the last one to release


### PR DESCRIPTION
Addresses #1273 where styles are not always being applied.

To apply styling to particular portion of text we need to have a position of where that text is. The trouble is that the changes/modifications supplied by _getVisibleParagraph_ don't provide a document paragraph index so it has to be queried with _firstVisibleParToAllParIndex_ which at that point in time returns stale values as [the scene graph hasn't been updated yet](https://github.com/FXMisc/Flowless/issues/123).

Here I've added a new method `getVisibleParagraphIndexes()` to _GenericStyledArea_ that returns a LiveList of **Tuple2<Integer,Paragraph>** items, where the Integer is the document index for the Paragraph.

