### PR TITLE
Fixes #1284 - JavaFX25 introduced getCaretShape to replace caretShape to fix

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -328,7 +328,7 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
     }
 
     private void updateSingleCaret(CaretNode caretNode) {
-        PathElement[] shape = getLeadingCaretShape(getClampedCaretPosition(caretNode));
+        PathElement[] shape = caretShape(getClampedCaretPosition(caretNode), true);
         caretNode.getElements().setAll(shape);
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ParagraphText.java
@@ -328,7 +328,7 @@ class ParagraphText<PS, SEG, S> extends TextFlowExt {
     }
 
     private void updateSingleCaret(CaretNode caretNode) {
-        PathElement[] shape = getCaretShape(getClampedCaretPosition(caretNode), true);
+        PathElement[] shape = getLeadingCaretShape(getClampedCaretPosition(caretNode));
         caretNode.getElements().setAll(shape);
     }
 

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
@@ -52,16 +52,6 @@ class TextFlowExt extends TextFlow {
         return navigator.offsetToPosition(charIdx, Forward).getMajor();
     }
 
-    /**
-     * The name of this method was changed from {@code getCaretShape} to {@code getLeadingCaretShape} because
-     * of the introduction in {@link TextFlow} of a method with the same name in JavaFX 25+.
-     * To make this method unique, the {@code isLeading} argument has been removed. If you need to use it, refer
-     * to the {@link TextFlow} class with the original method.
-     */
-    PathElement[] getLeadingCaretShape(int charIdx) {
-        return caretShape(charIdx, true);
-    }
-
     PathElement[] getRangeShape(IndexRange range) {
         return getRangeShape(range.getStart(), range.getEnd());
     }

--- a/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/TextFlowExt.java
@@ -52,8 +52,14 @@ class TextFlowExt extends TextFlow {
         return navigator.offsetToPosition(charIdx, Forward).getMajor();
     }
 
-    PathElement[] getCaretShape(int charIdx, boolean isLeading) {
-        return caretShape(charIdx, isLeading);
+    /**
+     * The name of this method was changed from {@code getCaretShape} to {@code getLeadingCaretShape} because
+     * of the introduction in {@link TextFlow} of a method with the same name in JavaFX 25+.
+     * To make this method unique, the {@code isLeading} argument has been removed. If you need to use it, refer
+     * to the {@link TextFlow} class with the original method.
+     */
+    PathElement[] getLeadingCaretShape(int charIdx) {
+        return caretShape(charIdx, true);
     }
 
     PathElement[] getRangeShape(IndexRange range) {


### PR DESCRIPTION
My only concern with this change is that by removing the method, if someone extended `TextFlowExt` and used the method, it will suddenly hit the one from JavaFX 25 which is slightly different.

That being said, there is no real fix for that, as JavaFX 25 will not go away.