### PR TITLE
docs(README): Add RedisFX to the project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Who uses RichTextFX?
 - [OmniEditor](https://github.com/giancosta86/OmniEditor)
 - [PMD Designer](https://github.com/pmd/pmd-designer/)
 - [Recaf](https://github.com/Col-E/Recaf)
+- [RedisFX](https://github.com/tanhuang2016/RedisFX)
 - [SqlBrowserFx](https://github.com/pariskol/sqlbrowserfx/)
 - [Squirrel SQL client](http://www.squirrelsql.org/)
 - [Xanthic](https://github.com/jrguenther/Xanthic)


### PR DESCRIPTION
Add a link to the RedisFX tool to the item list in the README.md file. This tool is a graphical management client for the Redis database.
