### PR TITLE
Changed Gradle version in distributionUrl to 8.5

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request fixes issue #1299 by changing the `distributionUrl` in gradle-wrapper.properties so that Gradle 8.5 is used. I have next to no experience with Gradle, so I'm not sure if gradle-wrapper.jar in the same directory ought to be updated as well, but this wasn't necessary to fix the problem.