### PR TITLE
Fixed JavaKeywordsDemo not updating highlighting on the correct lines when multiple changes happen in succession

### DIFF
--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
@@ -94,7 +94,7 @@ public class JavaKeywordsDemo extends Application {
 	                Set<Integer> linesChanged = positionsChanged.stream()
 			                .flatMap(range -> IntStream.rangeClosed(
 									codeArea.offsetToPosition(range.getStart(), Backward).getMajor(),
-					                codeArea.offsetToPosition(range.getEnd() - 1, Backward).getMajor())
+					                codeArea.offsetToPosition(Math.max(range.getEnd() - 1, 0), Backward).getMajor())
 					                .boxed())
 			                .collect(toSet());
                 	// re-style each line that was changed

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
@@ -1,7 +1,9 @@
 package org.fxmisc.richtext.demo;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -76,33 +78,12 @@ public class JavaKeywordsDemo extends Application {
                 .multiPlainChanges()
 
                 // do not emit an event until 500 ms have passed since the last emission of previous stream
-                .reduceSuccessions(
-						// We can't just add b to a and return a because a gets changed somewhere else
-						(a,b) -> Stream.concat(a.stream(), b.stream()).toList(),
-		                Duration.ofMillis(5000) )
+		        // in the meantime, store text changes in a list
+                .reduceSuccessions(this::concatChangeLists, // returns a new list because the lists passed in get modified elsewhere
+		                Duration.ofMillis(500) )
 
-                // run the following code block when previous stream emits an event
-                .subscribe(changes ->
-                {
-                	// work out which positions have been changed, remembering that later changes may affect the positions of earlier changes
-	                Set<IndexRange> positionsChanged = new HashSet<>();
-	                for (PlainTextChange change : changes) {
-		                shiftAllIndicesAtOrAboveThreshold(positionsChanged, change.getPosition(), change.getNetLength());
-						positionsChanged.add(new IndexRange(change.getPosition(), change.getInsertionEnd()));
-	                }
-					// work out the lines changed from the positions changed
-	                Set<Integer> linesChanged = positionsChanged.stream()
-			                .flatMap(range -> IntStream.rangeClosed(
-									codeArea.offsetToPosition(range.getStart(), Backward).getMajor(),
-					                codeArea.offsetToPosition(Math.max(range.getEnd() - 1, 0), Backward).getMajor())
-					                .boxed())
-			                .collect(toSet());
-                	// re-style each line that was changed
-                    for (int i : linesChanged)
-                	{
-                	    codeArea.setStyleSpans( i, 0, new JavaStyler( codeArea.getText(i) ).style() );
-                    }
-                });
+                // run this lambda to update syntax highlighting when previous stream emits an event
+                .subscribe(textChanges -> restyleChangedLines(codeArea, textChanges));
 
         // when no longer need syntax highlighting and wish to clean up memory leaks
         // run: `cleanupWhenNoLongerNeedIt.unsubscribe();`
@@ -117,19 +98,88 @@ public class JavaKeywordsDemo extends Application {
         primaryStage.show();
     }
 	
-	private void shiftAllIndicesAtOrAboveThreshold(Set<IndexRange> indexRanges, int threshold, int shift) {
-		if (shift != 0) {
-			Set<IndexRange> updatedRanges = new HashSet<>();
-			indexRanges.removeIf(range -> {
-				if (range.getEnd() >= threshold) {
-					int newEnd = Math.max(range.getEnd() + shift, threshold);
-					int newStart = range.getStart() >= threshold ? Math.max(range.getStart() + shift, threshold) : range.getStart();
-					updatedRanges.add(new IndexRange(newStart, newEnd));
-					return true;
-				}
-				return false;
-			});
-			indexRanges.addAll(updatedRanges);
+	private List<PlainTextChange> concatChangeLists(List<PlainTextChange> firstChanges, List<PlainTextChange> secondChanges) {
+		List<PlainTextChange> combinedChangeList = new ArrayList<>(firstChanges);
+		combinedChangeList.addAll(secondChanges);
+		return combinedChangeList;
+	}
+	
+	private void restyleChangedLines(CodeArea codeArea, List<PlainTextChange> textChanges) {
+		Set<IndexRange> positionsChanged = getPositionsChanged(textChanges);
+		Set<Integer> lineNumbersChanged = getLineNumbersChanged(codeArea, positionsChanged);
+		restyleLines(codeArea, lineNumbersChanged);
+	}
+	
+	// Converting positions to line numbers could be slow for large texts, so use IndexRanges instead of enumerating all positions
+	private Set<IndexRange> getPositionsChanged(List<PlainTextChange> textChanges) {
+		// Only the last change has up-to-date position data (i.e. up-to-date dirty range that needs restyling)
+		// Earlier changes need to have their positions updated by shifting them based on later changes
+		Set<IndexRange> dirtyRangesSoFar = new HashSet<>(); // Reflects changes that have happened so far as we go through them in order
+		for (PlainTextChange textChange : textChanges) {
+			dirtyRangesSoFar = updateDirtyRanges(dirtyRangesSoFar, textChange);
+		}
+		return dirtyRangesSoFar;
+	}
+	
+	private Set<IndexRange> updateDirtyRanges(Set<IndexRange> dirtyRangesSoFar, PlainTextChange nextChange) {
+		dirtyRangesSoFar = shiftIndicesAtOrAbovePosition(dirtyRangesSoFar, nextChange.getPosition(), nextChange.getNetLength());
+		dirtyRangesSoFar.add(new IndexRange(nextChange.getPosition(), nextChange.getInsertionEnd()));
+		return dirtyRangesSoFar;
+	}
+	
+	private Set<IndexRange> shiftIndicesAtOrAbovePosition(Set<IndexRange> indexRanges, int changePosition, int shift) {
+		if (shift == 0) {
+			return indexRanges;
+		} else {
+			return indexRanges.stream()
+					.map(range -> shiftRangeAtOrAbovePosition(range, changePosition, shift))
+					.collect(toSet());
+		}
+	}
+	
+	private IndexRange shiftRangeAtOrAbovePosition(IndexRange range, int changePosition, int shift) {
+		if (range.getEnd() >= changePosition) {
+			int newStart = shiftIndexAtOrAbovePosition(range.getStart(), changePosition, shift);
+			int newEnd = shiftIndexAtOrAbovePosition(range.getEnd(), changePosition, shift);
+			return new IndexRange(newStart, newEnd);
+		}
+		return range;
+	}
+	
+	private int shiftIndexAtOrAbovePosition(int index, int changePosition, int shift) {
+		if (index < changePosition) {
+			return index;
+		}
+		index += shift;
+		// index could now be lower than changePosition if the change deleted this character
+		// But deleted characters don't need restyling, so in that case just return changePosition, which already needs restyling
+		return Math.max(index, changePosition);
+	}
+	
+	private Set<Integer> getLineNumbersChanged(CodeArea codeArea, Set<IndexRange> positionsChanged) {
+		return positionsChanged.stream()
+				.flatMap(indexRange -> getLineNumbers(codeArea, indexRange))
+				.collect(toSet());
+	}
+	
+	private Stream<Integer> getLineNumbers(CodeArea codeArea, IndexRange indexRange) {
+		int startLineNumber = getLineNumber(codeArea, indexRange.getStart());
+		// indexRange has an exclusive end that needs 1 subtracting, but we don't want the end position to be before the start
+		int endPosition = Math.max(indexRange.getEnd() - 1, indexRange.getStart());
+		// getLineNumber() could be expensive for a huge text, so avoid calling if possible
+		int endLineNumber = endPosition == indexRange.getStart() ? startLineNumber : getLineNumber(codeArea, endPosition);
+		return IntStream.rangeClosed(startLineNumber, endLineNumber).boxed();
+	}
+	
+	private int getLineNumber(CodeArea codeArea, int position) {
+		return codeArea.offsetToPosition(position, Backward).getMajor();
+	}
+	
+	private void restyleLines(CodeArea codeArea, Set<Integer> lineNumbers) {
+		for (int lineNumber : lineNumbers)
+		{
+			String line = codeArea.getText(lineNumber);
+			codeArea.setStyleSpans( lineNumber, 0, new JavaStyler(line).style() );
 		}
 	}
 

--- a/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
+++ b/richtextfx-demos/src/main/java/org/fxmisc/richtext/demo/JavaKeywordsDemo.java
@@ -164,8 +164,8 @@ public class JavaKeywordsDemo extends Application {
 	
 	private Stream<Integer> getLineNumbers(CodeArea codeArea, IndexRange indexRange) {
 		int startLineNumber = getLineNumber(codeArea, indexRange.getStart());
-		// indexRange has an exclusive end that needs 1 subtracting, but we don't want the end position to be before the start
-		int endPosition = Math.max(indexRange.getEnd() - 1, indexRange.getStart());
+		// indexRange has an inclusive end because we also want to check the character after the change, which may have been moved to a new line
+		int endPosition = indexRange.getEnd();
 		// getLineNumber() could be expensive for a huge text, so avoid calling if possible
 		int endLineNumber = endPosition == indexRange.getStart() ? startLineNumber : getLineNumber(codeArea, endPosition);
 		return IntStream.rangeClosed(startLineNumber, endLineNumber).boxed();


### PR DESCRIPTION
This pull request fixes issue #1301 by accounting for the fact that later changes affect the line numbers of earlier changes.

This solution may be of help to those wanting a way to run updates only on lines that have been changed (e.g. for efficiency), whether that's for syntax highlighting or other operations. Issue #1273 seems related to this.