### PR TITLE
Fix for issue #1219

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/ClipboardActions.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/ClipboardActions.java
@@ -108,10 +108,21 @@ public interface ClipboardActions<PS, SEG, S> extends EditActions<PS, SEG, S> {
         if (clipboard.hasString()) {
             String text = clipboard.getString();
             if (text != null) {
+				text = removeEndingNullChars(text);
                 replaceSelection(text);
             }
         }
     }
+	
+	/**
+	 * Removes null characters that were appended to clipboard text on Windows, e.g. when copying from Microsoft Word.
+	 */
+	private String removeEndingNullChars(String text) {
+		if (text.endsWith("\u0000")) {
+			return text.replaceAll("\u0000+\\Z", "");
+		}
+		return text;
+	}
 }
 
 class ClipboardHelper {


### PR DESCRIPTION
This is a fix for issue #1219 when pasting plain text. I think codecs may need to handle the problem when pasting rich text, but the issue has only been observed for plain text and doesn't appear to happen when copying from a RichTextFX area.

The fix works by removing null characters at the end of the clipboard string, as it's hard to imagine when a user would want to insert these characters. Tests are unaffected by this change.