### PR TITLE
Cleanup `Paragraph` class after having covered it with UT

### DIFF
--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/Paragraph.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/Paragraph.java
@@ -261,19 +261,19 @@ public final class Paragraph<PS, SEG, S> {
     }
 
     public Paragraph<PS, SEG, S> trim(int length) {
-        if(length >= length()) {
-            return this;
-        } else {
-            Position pos = navigator.offsetToPosition(length, Backward);
-            int segIdx = pos.getMajor();
-            List<SEG> segs = new ArrayList<>(segIdx + 1);
-            segs.addAll(segments.subList(0, segIdx));
-            segs.add(segmentOps.subSequence(segments.get(segIdx), 0, pos.getMinor()));
-            if (segs.isEmpty()) {
-                segs.add(segmentOps.createEmptySeg());
-            }
-            return new Paragraph<>(paragraphStyle, segmentOps, segs, styles.subView(0, length));
+        length = Math.max(0, length);
+        if(length < length()) {
+            return trimTo(navigator.offsetToPosition(length, Backward));
         }
+        return this;
+    }
+
+    private Paragraph<PS, SEG, S> trimTo(Position position) {
+        int index = position.getMajor();
+        List<SEG> segments = new ArrayList<>(index + 1);
+        segments.addAll(this.segments.subList(0, index));
+        segments.add(segmentOps.subSequence(this.segments.get(index), 0, position.getMinor()));
+        return new Paragraph<>(paragraphStyle, segmentOps, segments, styles.subView(0, length));
     }
 
     public Paragraph<PS, SEG, S> subSequence(int start) {

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/Paragraph.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/Paragraph.java
@@ -338,14 +338,15 @@ public final class Paragraph<PS, SEG, S> {
         if(length() == 0) {
         	return new Paragraph<>(paragraphStyle, segmentOps, segments, (StyleSpans<S>) styleSpans);
         }
+        StyleSpans<S> updatedStyles = restyleExistingFrom(from, styleSpans);
+        return new Paragraph<>(paragraphStyle, segmentOps, segments, updatedStyles);
+    }
 
+    private StyleSpans<S> restyleExistingFrom(int from, StyleSpans<? extends S> styleSpans) {
+        int len = styleSpans.length();
         StyleSpans<S> left = styles.subView(0, from);
         StyleSpans<S> right = styles.subView(from + len, length());
-
-        // type issue with concat
-        StyleSpans<S> castedSpans = (StyleSpans<S>) styleSpans;
-        StyleSpans<S> updatedStyles = left.concat(castedSpans).concat(right);
-        return new Paragraph<>(paragraphStyle, segmentOps, segments, updatedStyles);
+        return left.concat((StyleSpans<S>) styleSpans).concat(right);
     }
 
     /**

--- a/richtextfx/src/main/java/org/fxmisc/richtext/model/Paragraph.java
+++ b/richtextfx/src/main/java/org/fxmisc/richtext/model/Paragraph.java
@@ -320,14 +320,13 @@ public final class Paragraph<PS, SEG, S> {
     }
 
     public Paragraph<PS, SEG, S> restyle(int from, int to, S style) {
-        if(from >= length()) {
-            return this;
-        } else {
+        if(from < length()) {
             StyleSpans<S> left = styles.subView(0, from);
             StyleSpans<S> right = styles.subView(to, length());
             StyleSpans<S> updatedStyles = left.append(style, to - from).concat(right);
             return new Paragraph<>(paragraphStyle, segmentOps, segments, updatedStyles);
         }
+        return this;
     }
 
     public Paragraph<PS, SEG, S> restyle(int from, StyleSpans<? extends S> styleSpans) {

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
@@ -170,7 +170,7 @@ public class ParagraphTest {
     public void trimParagraph() {
         Paragraph<Void, String, String> p1 = createTextParagraph(SegmentOps.styledTextOps(), "Alpha", "MyStyle");
         // Not very consistent that MIN_VALUE is throwing an exception while other negative numbers work
-        assertThrows(StringIndexOutOfBoundsException.class, () -> p1.trim(Integer.MIN_VALUE).getText());
+        assertEquals("", p1.trim(Integer.MIN_VALUE).getText());
         assertEquals("", p1.trim(-10).getText());
         assertEquals("", p1.trim(-1).getText());
         assertEquals("Alpha", p1.trim(Integer.MAX_VALUE).getText());
@@ -198,7 +198,7 @@ public class ParagraphTest {
         assertThrows(IndexOutOfBoundsException.class, () -> paragraph.delete(4, 10).getText()); // Not consistent with -1
         assertEquals("gated", paragraph.delete(0, 4).getText());
         assertEquals("gated", paragraph.delete(-1, 4).getText());
-        assertThrows(StringIndexOutOfBoundsException.class, () -> paragraph.delete(Integer.MIN_VALUE, 4).getText()); // Not very consistent with -1
+        assertEquals("gated", paragraph.delete(Integer.MIN_VALUE, 4).getText());
 
         // Check style too
         Paragraph<Void, String, String> p2 = paragraph.delete(2, 5);

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
@@ -21,9 +21,9 @@ public class ParagraphTest {
         assertEquals(ranges.length/2, styleSpans.getSpanCount(), "Style segment count invalid");
         for (int i = 0; i < ranges.length/2 ; i++) {
             StyleSpan<T> style = styleSpans.getStyleSpan(i);
+            assertEquals(styles[i], style.getStyle(), "Incorrect style for " + i);
             assertEquals(ranges[i*2], style.getStart(), "Start not matching for " + i);
             assertEquals(ranges[i*2 + 1] - ranges[i*2], style.getLength(), "Length not matching for " + i);
-            assertEquals(styles[i], style.getStyle(), "Incorrect style for " + i);
         }
     }
 
@@ -257,8 +257,13 @@ public class ParagraphTest {
         Paragraph<Void, String, String> p3 = p2.restyle(3, 10, "unknown");
         checkStyle(p3, 18, new String[] {"text", "unknown", "keyword", "text"}, 0, 3, 3, 10, 10, 12, 12, 18);
 
+        // Restyle in bound
+        // Bug
+        checkStyle(p3.restyle(11, 18, "out"), 18,
+                new String[] {"text", "unknown", "keyword", "out"},
+                0, 3, 3, 10, 0, 1, 0, 7);
+
         // Restyle out of bound
-        // Bug: the styles are totally off
         checkStyle(p3.restyle(11, 19, "out"), 19,
                 new String[] {"text", "unknown", "keyword", "out"},
                 0, 3, 3, 10, 0, 1, 0, 8);

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
@@ -244,6 +244,10 @@ public class ParagraphTest {
         Paragraph<Void, String, String> p1 = createTextParagraph("To be or not to be", "text");
         checkStyle(p1, 18, new String[] {"text"}, 0, 18);
 
+        // Restyle with same style
+        Paragraph<Void, String, String> p1b = p1.restyle(0, 18, "text");
+        checkStyle(p1b, 18, new String[] {"text"}, 0, 18);
+
         // P1 is immutable, its style hasn't changed, but P2 has now three styles
         Paragraph<Void, String, String> p2 = p1.restyle(9, 12, "keyword");
         checkStyle(p1, 18, new String[] {"text"}, 0, 18);

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import javafx.scene.control.IndexRange;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class ParagraphTest {
@@ -155,6 +156,17 @@ public class ParagraphTest {
     }
 
     @Test
+    @DisplayName("Trim on empty text should return empty")
+    public void trimOnEmpty() {
+        Paragraph<Void, String, Void> p1 = createTextParagraph(SegmentOps.styledTextOps(), "");
+        assertEquals("", p1.trim(-1).getText());
+        assertEquals("", p1.trim(0).getText());
+        assertEquals("", p1.trim(1).getText());
+        assertEquals("", p1.trim(Integer.MAX_VALUE).getText());
+    }
+
+    @Test
+    @DisplayName("Trim text should return the text until the provided position")
     public void trimParagraph() {
         Paragraph<Void, String, String> p1 = createTextParagraph(SegmentOps.styledTextOps(), "Alpha", "MyStyle");
         // Not very consistent that MIN_VALUE is throwing an exception while other negative numbers work

--- a/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
+++ b/richtextfx/src/test/java/org/fxmisc/richtext/model/ParagraphTest.java
@@ -257,7 +257,12 @@ public class ParagraphTest {
         Paragraph<Void, String, String> p3 = p2.restyle(3, 10, "unknown");
         checkStyle(p3, 18, new String[] {"text", "unknown", "keyword", "text"}, 0, 3, 3, 10, 10, 12, 12, 18);
 
-        // Restyle in bound
+        // Restyle up to the end
+        checkStyle(p3.restyle(11, 17, "out"), 18,
+                new String[] {"text", "unknown", "keyword", "out", "text"},
+                0, 3, 3, 10, 10, 11, 11, 17, 17, 18);
+
+        // Restyle up to the end
         // Bug
         checkStyle(p3.restyle(11, 18, "out"), 18,
                 new String[] {"text", "unknown", "keyword", "out"},


### PR DESCRIPTION
As per title. Tests were previously added and merged and this branch is used to clean it up.

Note that I did change a little behaviour here, the trim method is now capping the end value to not allow negative number.
```Java
public Paragraph<PS, SEG, S> trim(int end) {
    end = Math.max(0, end);
    // ...
}
```